### PR TITLE
Add Docker support for home server deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.venv
+.env
+.tv-token
+.cache
+__pycache__
+*.pyc
+*.egg-info
+.pytest_cache
+tests
+.github
+.playwright-mcp
+ai_config.json
+api_usage.json
+artwork_meta.json
+collections.json
+drive_sync.json

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Docker
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libjpeg62-turbo-dev \
+      zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY server.py index.html ./
+COPY assets/ assets/
+
+ENV DOCENT_DATA_DIR=/data
+EXPOSE 8000
+
+CMD ["uv", "run", "python3", "server.py"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Send any image to your Samsung Frame TV with one click.
 
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green)
+![Docker](https://img.shields.io/badge/docker-supported-blue?logo=docker)
 
 Docent is a local web app that puts art on your TV. Drop an image in, press **"Display on Frame,"** and it appears on your screen — no Samsung app, no USB drive, no cloud upload. It also manages your full gallery with a museum-quality interface: browse, organize into collections, crop to 16:9, and swap what's showing anytime. Add AI art identification, weather-aware recommendations, and Google Drive import.
 
@@ -158,6 +159,35 @@ docent/
 ```
 
 Data files are auto-created on first run and git-ignored: `.tv-token`, `ai_config.json`, `api_usage.json`, `drive_sync.json`, `artwork_meta.json`, `collections.json`.
+
+## Docker
+
+Docker is the easiest way to run Docent on Linux, Unraid, Synology, or any home server.
+
+```bash
+# Clone and configure
+git clone https://github.com/danmunz/docent.git
+cd docent
+cp .env.example .env
+# Edit .env and set DOCENT_TV_IP
+
+# Run with Docker Compose
+docker compose up -d
+```
+
+Or without Compose:
+
+```bash
+docker build -t docent .
+docker run -d --network host \
+  -e DOCENT_TV_IP=192.168.1.XXX \
+  -v docent-data:/data \
+  --name docent docent
+```
+
+Open **http://localhost:8000** in your browser.
+
+`--network host` is recommended so the server can reach your TV on the local network. Data (artwork metadata, caches, TV token) persists in the `docent-data` volume.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  docent:
+    build: .
+    # image: ghcr.io/danmunz/docent:latest  # use this once images are published
+    network_mode: host  # required for TV WebSocket discovery on LAN
+    volumes:
+      - docent-data:/data
+    environment:
+      - DOCENT_TV_IP=${DOCENT_TV_IP:?Set DOCENT_TV_IP in .env or shell}
+    env_file:
+      - path: .env
+        required: false
+    restart: unless-stopped
+
+volumes:
+  docent-data:


### PR DESCRIPTION
## Summary

Adds Docker support so Docent can run on Linux home servers (Unraid, Synology, Raspberry Pi, etc.) with zero dependency management.

> "I'd love to see this as a docker container (and in the Unraid store). The alternative is setting up a new virtual machine and the overhead and maintenance of a full operating system just to do a small task."

**Depends on #40** — merge that first, then rebase this PR onto `main`.

## Changes

- **`Dockerfile`** — Python 3.13-slim, Pillow system deps, uv for fast installs, `DOCENT_DATA_DIR=/data`
- **`docker-compose.yml`** — host networking for TV LAN access, named volume for persistent data, `.env` passthrough
- **`.dockerignore`** — keeps build context clean (no .git, .venv, data files, tests)
- **`.github/workflows/docker.yml`** — multi-arch CI (linux/amd64 + linux/arm64), pushes to GHCR on version tags, GHA build cache
- **README** — Docker badge, Docker section with `docker compose` and `docker run` examples

## Usage

```bash
docker compose up -d
# or
docker run -d --network host -e DOCENT_TV_IP=192.168.1.XXX -v docent-data:/data docent
```

## Remaining (post-merge)

- [ ] Test on Linux with `docker run` and `docker compose`
- [ ] Tag a release to trigger first GHCR image publish
- [ ] Unraid Community Applications template (future)

Closes #38