### PR TITLE
fix: uploads crash on every request (async-for on UploadFile)

### DIFF
--- a/server.py
+++ b/server.py
@@ -390,7 +390,10 @@ async def upload_art(
 ):
     chunks = []
     total = 0
-    async for chunk in file:
+    while True:
+        chunk = await file.read(1024 * 1024)
+        if not chunk:
+            break
         total += len(chunk)
         if total > MAX_UPLOAD_BYTES:
             raise HTTPException(413, f"File exceeds {MAX_UPLOAD_BYTES // (1024 * 1024)}MB limit")

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,52 @@
+"""Tests for the /api/upload endpoint.
+
+Regression coverage for the upload path, which had no tests — a size-limit
+change (commit c96df06) replaced ``await file.read()`` with
+``async for chunk in file`` which raises ``TypeError`` on a Starlette
+``UploadFile`` (it is not async-iterable), breaking every upload.
+"""
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+
+def _image_bytes(fmt: str = "PNG", size: tuple[int, int] = (32, 32)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, (12, 34, 56)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestUpload:
+    async def test_upload_reads_file_and_pushes_to_tv(self, client, mock_tv):
+        """A normal upload streams the file and reaches the TV (regression:
+        the streaming read used to crash with a TypeError)."""
+        mock_tv.upload.return_value = "MY_F0001"
+
+        resp = await client.post(
+            "/api/upload",
+            files={"file": ("art.png", _image_bytes(), "image/png")},
+            data={"matte": "none", "filename": "Test Art"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["content_id"] == "MY_F0001"
+        assert body["title"] == "Test Art"
+        assert mock_tv.upload.called
+
+    async def test_upload_enforces_size_limit(self, client, mock_tv, monkeypatch):
+        """The 50 MB cap (the reason the streaming read was introduced) still
+        works: an oversized upload is rejected with 413."""
+        monkeypatch.setattr("server.MAX_UPLOAD_BYTES", 8)  # smaller than any real image
+
+        resp = await client.post(
+            "/api/upload",
+            files={"file": ("big.png", _image_bytes(), "image/png")},
+            data={"matte": "none"},
+        )
+
+        assert resp.status_code == 413
+        assert not mock_tv.upload.called


### PR DESCRIPTION
## What

`/api/upload` has crashed on **every** request since commit `c96df06` ("enforce 50 MB upload size limit"). That change replaced `data = await file.read()` with:

```python
async for chunk in file:
    ...
```

A Starlette `UploadFile` is **not** async-iterable (no `__aiter__`), so this raises `TypeError: 'async for' requires an object with __aiter__ method, got UploadFile` and the endpoint 500s. Uploading art to the TV is fully broken in v1.0.0.

## Fix

Stream the file with a chunked `await file.read()` loop that still enforces `MAX_UPLOAD_BYTES` (the reason streaming was introduced in the first place):

```python
while True:
    chunk = await file.read(1024 * 1024)
    if not chunk:
        break
    total += len(chunk)
    if total > MAX_UPLOAD_BYTES:
        raise HTTPException(413, ...)
    chunks.append(chunk)
```

## Tests

Adds `tests/test_upload.py` — the coverage the endpoint was missing (which is why this shipped):

- a normal upload reaches the TV → **fails on the old code** with the `TypeError`, passes on the fix
- the 50 MB cap still rejects oversized files (413)

`PYTHONPATH=. uv run pytest -q` → all green.

---

### A note from a happy user 🙂

Full disclosure: this PR was written with AI assistance (Claude Code). I'm not hand-authoring it. But it came straight out of fixing my own Frame, and I'd rather give it back than keep it local.

Docent finally made this work for me. **In ~7 years I have never been able to get images onto my Frame this easily.** I genuinely love this solution. So thank you for building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
