### PR TITLE
feat: resilient, non-blocking TV connection (WoL + retry + timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,12 @@ Copy `.env.example` to `.env` and edit:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DOCENT_TV_IP` | *(required)* | Your Samsung Frame TV's IP address |
+| `DOCENT_TV_MAC` | *(unset)* | TV's MAC address. When set, Docent sends a Wake-on-LAN packet to wake a sleeping Frame before retrying a connection. Find it with `arp -n <tv-ip>`. |
 | `DOCENT_TV_PORT` | `8001` | TV WebSocket port |
-| `DOCENT_TV_TIMEOUT` | `15` | Connection timeout in seconds |
+| `DOCENT_TV_TIMEOUT` | `10` | Per-attempt TV connection/operation timeout in seconds |
+| `DOCENT_TV_ATTEMPTS` | `3` | How many times to retry establishing a TV connection (the Frame often accepts the socket without answering the art handshake) |
+| `DOCENT_TV_RETRY_DELAY` | `2` | Seconds to wait between TV connection attempts |
+| `DOCENT_RELOAD` | *(off)* | Set to `1` to enable uvicorn auto-reload (development only — off by default so writing data files can't restart the server mid-operation) |
 | `DOCENT_HOST` | `0.0.0.0` | Server bind address |
 | `DOCENT_PORT` | `8000` | Server port |
 | `DOCENT_DATA_DIR` | project root | Directory for data files (`.tv-token`, caches, JSON config) |

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import socket
 import tempfile
 import uuid
 from contextlib import asynccontextmanager
@@ -19,6 +20,7 @@ from fastapi.responses import FileResponse, JSONResponse, Response
 from starlette.staticfiles import StaticFiles
 from PIL import Image
 from samsungtvws import SamsungTVWS
+from samsungtvws.exceptions import ResponseError
 
 try:
     from dotenv import load_dotenv
@@ -28,7 +30,16 @@ except ImportError:
 
 TV_IP = os.environ.get("DOCENT_TV_IP", "")
 TV_PORT = int(os.environ.get("DOCENT_TV_PORT", "8001"))
-TV_TIMEOUT = int(os.environ.get("DOCENT_TV_TIMEOUT", "15"))
+TV_TIMEOUT = int(os.environ.get("DOCENT_TV_TIMEOUT", "10"))
+# Wake-on-LAN target (the TV's MAC). When set, Docent wakes a sleeping Frame
+# before retrying a failed connection. Find it with: arp -n <tv-ip>
+TV_MAC = os.environ.get("DOCENT_TV_MAC", "")
+# How many times to (re)try establishing a TV conversation, and how long to
+# wait between tries. The Frame frequently accepts the TCP connection without
+# answering the art-mode handshake (busy with its on-screen UI, or mid
+# sleep/wake), so a single attempt is unreliable — we wake + retry.
+TV_CONNECT_ATTEMPTS = int(os.environ.get("DOCENT_TV_ATTEMPTS", "3"))
+TV_RETRY_DELAY = float(os.environ.get("DOCENT_TV_RETRY_DELAY", "2"))
 
 DATA_DIR = Path(os.environ.get("DOCENT_DATA_DIR", "") or Path(__file__).parent)
 TOKEN_FILE = DATA_DIR / ".tv-token"
@@ -77,6 +88,81 @@ def art_connection(tv: SamsungTVWS):
         tv.close()
         raise
     return art
+
+
+def _wake_tv() -> None:
+    """Send a Wake-on-LAN magic packet to the TV (no-op if no MAC configured).
+
+    The Samsung Frame parks its art-mode service to save power; a WoL packet
+    nudges it awake so the next connection attempt can succeed.
+    """
+    if not TV_MAC:
+        return
+    mac = TV_MAC.replace(":", "").replace("-", "").strip()
+    if len(mac) != 12:
+        log.debug("Ignoring malformed DOCENT_TV_MAC: %r", TV_MAC)
+        return
+    try:
+        packet = b"\xff" * 6 + bytes.fromhex(mac) * 16
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            s.sendto(packet, ("255.255.255.255", 9))
+            if TV_IP:
+                s.sendto(packet, (TV_IP, 9))
+        finally:
+            s.close()
+    except Exception as e:
+        log.debug("WoL send failed: %s", e)
+
+
+async def _tv_op(fn, *, attempts: int = TV_CONNECT_ATTEMPTS, timeout: float | None = None):
+    """Run a blocking TV operation off the event loop, reliably.
+
+    Opens a TV/art connection, runs ``fn(art)`` in a worker thread, then
+    closes the connection. Access is serialized by ``_tv_lock`` so only one
+    TV conversation happens at a time (the Frame dislikes concurrent
+    connections), while the event loop stays free to serve other requests.
+
+    Each attempt is bounded by ``timeout`` (default ``TV_TIMEOUT + 8``) so a
+    hung connection can never hold the lock forever — it raises and releases.
+    On a connection-type failure we send a Wake-on-LAN packet and retry up to
+    ``attempts`` times. A definitive ``ResponseError`` from the TV (e.g. the
+    matte "-10" rejection) is not retried.
+
+    Pass ``attempts=1`` for non-idempotent calls like uploads (so a lost
+    response can't trigger a duplicate), with a larger ``timeout`` to allow
+    the data transfer.
+    """
+    if timeout is None:
+        timeout = TV_TIMEOUT + 8
+
+    def _job():
+        tv = get_tv()
+        art = art_connection(tv)
+        try:
+            return fn(art)
+        finally:
+            tv.close()
+
+    async with _tv_lock:
+        last_exc: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                return await asyncio.wait_for(asyncio.to_thread(_job), timeout=timeout)
+            except ResponseError:
+                raise  # TV answered with a definitive error — retrying won't help
+            except Exception as e:
+                last_exc = e
+                if attempt + 1 < attempts:
+                    log.info(
+                        "TV op attempt %d/%d failed (%s) — waking TV and retrying",
+                        attempt + 1, attempts, type(e).__name__,
+                    )
+                    _wake_tv()
+                    await asyncio.sleep(TV_RETRY_DELAY)
+        assert last_exc is not None
+        raise last_exc
 
 
 def _save_thumbnail(content_id: str, data: bytes | bytearray) -> None:
@@ -244,21 +330,17 @@ async def index():
 
 @app.get("/api/info")
 async def tv_info():
+    def _info(art):
+        supported = art.supported()
+        return {
+            "supported": supported,
+            "api_version": art.get_api_version() if supported else None,
+            "artmode": art.get_artmode() if supported else None,
+            "ip": TV_IP,
+        }
+
     try:
-        tv = get_tv()
-        art = art_connection(tv)
-        try:
-            supported = art.supported()
-            api_version = art.get_api_version() if supported else None
-            artmode = art.get_artmode() if supported else None
-            return {
-                "supported": supported,
-                "api_version": api_version,
-                "artmode": artmode,
-                "ip": TV_IP,
-            }
-        finally:
-            tv.close()
+        return await _tv_op(_info)
     except Exception as e:
         log.warning("TV connection failed: %s", e)
         raise HTTPException(502, "Cannot reach TV — is it on and connected?")
@@ -267,13 +349,7 @@ async def tv_info():
 @app.get("/api/device-info")
 async def device_info():
     try:
-        tv = get_tv()
-        art = art_connection(tv)
-        try:
-            info = art.get_device_info()
-            return {"device_info": info}
-        finally:
-            tv.close()
+        return await _tv_op(lambda art: {"device_info": art.get_device_info()})
     except Exception as e:
         log.warning("TV connection failed: %s", e)
         raise HTTPException(502, "Cannot reach TV — is it on and connected?")
@@ -310,17 +386,11 @@ async def get_thumbnail(content_id: str):
     cached = _get_cached_thumbnail(content_id)
     if cached:
         return Response(content=cached, media_type="image/jpeg")
-    async with _tv_lock:
-        tv = get_tv()
-        art = art_connection(tv)
-        try:
-            data = art.get_thumbnail(content_id)
-            if not data:
-                raise HTTPException(404, "No thumbnail")
-            _save_thumbnail(content_id, data)
-            return Response(content=bytes(data), media_type="image/jpeg")
-        finally:
-            tv.close()
+    data = await _tv_op(lambda art: art.get_thumbnail(content_id))
+    if not data:
+        raise HTTPException(404, "No thumbnail")
+    _save_thumbnail(content_id, data)
+    return Response(content=bytes(data), media_type="image/jpeg")
 
 
 @app.post("/api/thumbnails")
@@ -341,19 +411,13 @@ async def get_thumbnails_batch(body: dict):
 
     if missing:
         try:
-            async with _tv_lock:
-                tv = get_tv()
-                art = art_connection(tv)
-                try:
-                    result = art.get_thumbnail_list(missing)
-                    for name, data in result.items():
-                        for cid in missing:
-                            if name.startswith(cid):
-                                _save_thumbnail(cid, data)
-                                encoded[cid] = base64.b64encode(bytes(data)).decode()
-                                break
-                finally:
-                    tv.close()
+            result = await _tv_op(lambda art: art.get_thumbnail_list(missing))
+            for name, data in result.items():
+                for cid in missing:
+                    if name.startswith(cid):
+                        _save_thumbnail(cid, data)
+                        encoded[cid] = base64.b64encode(bytes(data)).decode()
+                        break
         except Exception as e:
             log.warning("Batch thumbnail fetch failed: %s", e)
 
@@ -364,19 +428,14 @@ async def get_thumbnails_batch(body: dict):
 
 @app.post("/api/select")
 async def select_art(body: dict):
+    global _current_id_cache
     content_id = body.get("content_id")
     if not content_id:
         raise HTTPException(400, "content_id required")
     _validate_content_id(content_id)
-    tv = get_tv()
-    art = art_connection(tv)
-    try:
-        art.select_image(content_id, show=True)
-        global _current_id_cache
-        _current_id_cache = content_id
-        return {"ok": True, "content_id": content_id}
-    finally:
-        tv.close()
+    await _tv_op(lambda art: art.select_image(content_id, show=True))
+    _current_id_cache = content_id
+    return {"ok": True, "content_id": content_id}
 
 
 # --- Upload ---
@@ -422,62 +481,62 @@ async def upload_art(
 
     original_name = filename.strip() or Path(file.filename or "image.jpg").stem
 
-    tv = get_tv()
-    art = art_connection(tv)
-    try:
-        log.info("Uploading %s (%dx%d, ext=%s, matte=%s)", original_name, w, h, ext, matte)
-        content_id = art.upload(data, matte=matte, file_type=ext)
-        _invalidate_art_cache()
+    # Push to the TV off the event loop so this (often slow) call doesn't
+    # freeze the rest of the app.
+    log.info("Uploading %s (%dx%d, ext=%s, matte=%s)", original_name, w, h, ext, matte)
+    content_id = await _tv_op(
+        lambda art: art.upload(data, matte=matte, file_type=ext),
+        attempts=1, timeout=120,
+    )
+    _invalidate_art_cache()
 
-        analysis_img = img.copy()
-        analysis_img.thumbnail((1280, 720), Image.LANCZOS)
-        buf = io.BytesIO()
-        analysis_img.save(buf, format="JPEG", quality=80)
-        (ORIGINALS_DIR / f"{content_id}.jpg").write_bytes(buf.getvalue())
+    analysis_img = img.copy()
+    analysis_img.thumbnail((1280, 720), Image.LANCZOS)
+    buf = io.BytesIO()
+    analysis_img.save(buf, format="JPEG", quality=80)
+    (ORIGINALS_DIR / f"{content_id}.jpg").write_bytes(buf.getvalue())
 
-        async with _meta_lock:
-            meta = _load_artwork_meta()
-            meta["artwork"][content_id] = {
-                "title": original_name,
-                "original_filename": file.filename or "",
-                "width": w,
-                "height": h,
-                "uploaded_at": datetime.now(timezone.utc).isoformat(),
-            }
-            _save_artwork_meta(meta)
+    async with _meta_lock:
+        meta = _load_artwork_meta()
+        meta["artwork"][content_id] = {
+            "title": original_name,
+            "original_filename": file.filename or "",
+            "width": w,
+            "height": h,
+            "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _save_artwork_meta(meta)
 
-        ai_result = None
-        ai_config = _load_ai_config()
-        provider = ai_config.get("provider", "claude")
-        has_key = bool(ai_config.get(provider, {}).get("api_key"))
-        should_analyze = ai_config.get("auto_analyze") and has_key
+    ai_result = None
+    ai_config = _load_ai_config()
+    provider = ai_config.get("provider", "claude")
+    has_key = bool(ai_config.get(provider, {}).get("api_key"))
+    should_analyze = ai_config.get("auto_analyze") and has_key
 
-        if analyze and should_analyze:
-            if not (THUMB_DIR / f"{content_id}.jpg").exists():
-                try:
-                    thumb_data = art.get_thumbnail(content_id)
-                    if thumb_data:
-                        _save_thumbnail(content_id, thumb_data)
-                except Exception:
-                    log.debug("Could not pre-fetch thumbnail for %s", content_id)
+    if analyze and should_analyze:
+        if not (THUMB_DIR / f"{content_id}.jpg").exists():
             try:
-                ai_result = await _analyze_artwork(content_id)
-            except Exception as e:
-                log.warning("Auto-analyze failed during upload for %s: %s", content_id, e)
-                ai_result = {"error": "Analysis failed"}
-        elif should_analyze:
-            asyncio.create_task(_analyze_artwork_background(content_id))
+                thumb_data = await _tv_op(lambda art: art.get_thumbnail(content_id))
+                if thumb_data:
+                    _save_thumbnail(content_id, thumb_data)
+            except Exception:
+                log.debug("Could not pre-fetch thumbnail for %s", content_id)
+        try:
+            ai_result = await _analyze_artwork(content_id)
+        except Exception as e:
+            log.warning("Auto-analyze failed during upload for %s: %s", content_id, e)
+            ai_result = {"error": "Analysis failed"}
+    elif should_analyze:
+        asyncio.create_task(_analyze_artwork_background(content_id))
 
-        resp = {"ok": True, "content_id": content_id, "title": original_name, "width": w, "height": h}
-        if ai_result:
-            if "error" in ai_result:
-                resp["ai_error"] = ai_result["error"]
-            else:
-                resp["ai_meta"] = ai_result["ai_meta"]
-                resp["title"] = ai_result.get("title", original_name)
-        return resp
-    finally:
-        tv.close()
+    resp = {"ok": True, "content_id": content_id, "title": original_name, "width": w, "height": h}
+    if ai_result:
+        if "error" in ai_result:
+            resp["ai_error"] = ai_result["error"]
+        else:
+            resp["ai_meta"] = ai_result["ai_meta"]
+            resp["title"] = ai_result.get("title", original_name)
+    return resp
 
 
 # --- Delete ---
@@ -488,21 +547,16 @@ async def delete_art(body: dict):
     if not content_ids:
         raise HTTPException(400, "content_ids required")
     _validate_content_ids(content_ids)
-    tv = get_tv()
-    art = art_connection(tv)
-    try:
-        ok = art.delete_list(content_ids)
+    ok = await _tv_op(lambda art: art.delete_list(content_ids))
+    for cid in content_ids:
+        (THUMB_DIR / f"{cid}.jpg").unlink(missing_ok=True)
+    _invalidate_art_cache()
+    async with _meta_lock:
+        meta = _load_artwork_meta()
         for cid in content_ids:
-            (THUMB_DIR / f"{cid}.jpg").unlink(missing_ok=True)
-        _invalidate_art_cache()
-        async with _meta_lock:
-            meta = _load_artwork_meta()
-            for cid in content_ids:
-                meta["artwork"].pop(cid, None)
-            _save_artwork_meta(meta)
-        return {"ok": ok}
-    finally:
-        tv.close()
+            meta["artwork"].pop(cid, None)
+        _save_artwork_meta(meta)
+    return {"ok": ok}
 
 
 # --- Matte ---
@@ -510,14 +564,9 @@ async def delete_art(body: dict):
 @app.get("/api/mattes")
 async def list_mattes():
     try:
-        tv = get_tv()
+        return await _tv_op(lambda art: art.get_matte_list())
     except Exception:
         raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        return art.get_matte_list()
-    finally:
-        tv.close()
 
 
 @app.post("/api/matte")
@@ -527,22 +576,14 @@ async def change_matte(body: dict):
     if not content_id:
         raise HTTPException(400, "content_id required")
     _validate_content_id(content_id)
+    log.info("Changing matte: content_id=%s, matte_id=%s", content_id, matte_id)
     try:
-        tv = get_tv()
-    except Exception:
-        raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        log.info("Changing matte: content_id=%s, matte_id=%s", content_id, matte_id)
-        art.change_matte(content_id, matte_id)
+        await _tv_op(lambda art: art.change_matte(content_id, matte_id))
         return {"ok": True}
     except Exception as e:
-        err = str(e)
-        if "error number" in err:
-            raise HTTPException(422, f"TV rejected matte change — this image may not support that matte style")
-        raise
-    finally:
-        tv.close()
+        if "error number" in str(e):
+            raise HTTPException(422, "TV rejected matte change — this image may not support that matte style")
+        raise HTTPException(502, "Cannot reach TV")
 
 
 # --- Favourite ---
@@ -555,15 +596,10 @@ async def toggle_favourite(body: dict):
         raise HTTPException(400, "content_id required")
     _validate_content_id(content_id)
     try:
-        tv = get_tv()
+        await _tv_op(lambda art: art.set_favourite(content_id, status))
+        return {"ok": True}
     except Exception:
         raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        art.set_favourite(content_id, status)
-        return {"ok": True}
-    finally:
-        tv.close()
 
 
 # --- Art mode toggle ---
@@ -574,15 +610,10 @@ async def set_artmode(body: dict):
     if mode is None:
         raise HTTPException(400, "mode required (true/false)")
     try:
-        tv = get_tv()
+        await _tv_op(lambda art: art.set_artmode(mode))
+        return {"ok": True, "mode": mode}
     except Exception:
         raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        art.set_artmode(mode)
-        return {"ok": True, "mode": mode}
-    finally:
-        tv.close()
 
 
 # --- Photo filters ---
@@ -590,14 +621,9 @@ async def set_artmode(body: dict):
 @app.get("/api/filters")
 async def get_filters():
     try:
-        tv = get_tv()
+        return await _tv_op(lambda art: {"filters": art.get_photo_filter_list()})
     except Exception:
         raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        return {"filters": art.get_photo_filter_list()}
-    finally:
-        tv.close()
 
 
 @app.post("/api/filter")
@@ -608,15 +634,10 @@ async def set_filter(body: dict):
         raise HTTPException(400, "content_id and filter_id required")
     _validate_content_id(content_id)
     try:
-        tv = get_tv()
+        await _tv_op(lambda art: art.set_photo_filter(content_id, filter_id))
+        return {"ok": True}
     except Exception:
         raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        art.set_photo_filter(content_id, filter_id)
-        return {"ok": True}
-    finally:
-        tv.close()
 
 
 # --- Slideshow ---
@@ -627,19 +648,16 @@ async def set_slideshow(body: dict):
     shuffle = body.get("shuffle", True)
     category_id = body.get("category_id")
     try:
-        tv = get_tv()
-    except Exception:
-        raise HTTPException(502, "Cannot reach TV")
-    art = art_connection(tv)
-    try:
-        art.set_slideshow_status(
-            duration=duration,
-            type=shuffle,
-            category_id=category_id,
+        await _tv_op(
+            lambda art: art.set_slideshow_status(
+                duration=duration,
+                type=shuffle,
+                category_id=category_id,
+            )
         )
         return {"ok": True}
-    finally:
-        tv.close()
+    except Exception:
+        raise HTTPException(502, "Cannot reach TV")
 
 
 # --- Collections ---
@@ -1553,12 +1571,10 @@ async def run_drive_sync(sync_id: str):
                     ext = "jpg"
 
                 matte = "shadowbox_polar"
-                tv = get_tv()
-                art = art_connection(tv)
-                try:
-                    content_id = art.upload(image_data, matte=matte, file_type=ext)
-                finally:
-                    tv.close()
+                content_id = await _tv_op(
+                    lambda art: art.upload(image_data, matte=matte, file_type=ext),
+                    attempts=1, timeout=120,
+                )
 
                 _invalidate_art_cache()
 
@@ -1890,7 +1906,20 @@ def main():
     import uvicorn
     host = os.environ.get("DOCENT_HOST", "0.0.0.0")
     port = int(os.environ.get("DOCENT_PORT", "8000"))
-    uvicorn.run("server:app", host=host, port=port, reload=True)
+    # Auto-reload is OFF by default. Docent writes its own data (cache,
+    # *.json, token) into this folder, so watching it would restart the
+    # server mid-upload and kill in-flight work. Developers can opt in with
+    # DOCENT_RELOAD=1; even then we exclude the data files from the watcher.
+    if os.environ.get("DOCENT_RELOAD") == "1":
+        uvicorn.run(
+            "server:app",
+            host=host,
+            port=port,
+            reload=True,
+            reload_excludes=[".cache/*", "*.json", ".tv-token"],
+        )
+    else:
+        uvicorn.run("server:app", host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -390,7 +390,10 @@ async def upload_art(
 ):
     chunks = []
     total = 0
-    async for chunk in file:
+    while True:
+        chunk = await file.read(1024 * 1024)
+        if not chunk:
+            break
         total += len(chunk)
         if total > MAX_UPLOAD_BYTES:
             raise HTTPException(413, f"File exceeds {MAX_UPLOAD_BYTES // (1024 * 1024)}MB limit")

--- a/tests/test_tv_reliability.py
+++ b/tests/test_tv_reliability.py
@@ -1,0 +1,135 @@
+"""Tests for the resilient TV connection helper (`_tv_op`) and Wake-on-LAN.
+
+The Samsung Frame frequently accepts the TCP socket without answering the
+art-mode handshake (busy with its on-screen UI, or mid sleep/wake), so a
+single connection attempt is unreliable. `_tv_op` retries with a Wake-on-LAN
+nudge and bounds each attempt with a timeout so a hung call can never hold the
+TV lock forever.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import server
+from samsungtvws.exceptions import ResponseError
+
+
+def _ok_tv():
+    tv = MagicMock()
+    art = MagicMock()
+    tv.art.return_value = art
+    art.open.return_value = None
+    art.supported.return_value = True
+    return tv
+
+
+class TestTvOpReliability:
+    async def test_retries_then_succeeds_and_wakes_tv(self, monkeypatch):
+        """A first connection failure triggers a Wake-on-LAN and a retry that
+        succeeds — rather than surfacing as 'TV went to sleep'."""
+        attempts = {"n": 0}
+
+        def flaky_get_tv():
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise OSError("No route to host")
+            return _ok_tv()
+
+        woke = {"n": 0}
+        monkeypatch.setattr(server, "get_tv", flaky_get_tv)
+        monkeypatch.setattr(server, "_wake_tv", lambda: woke.__setitem__("n", woke["n"] + 1))
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0)
+
+        result = await server._tv_op(lambda art: art.supported())
+
+        assert result is True
+        assert attempts["n"] == 2   # retried exactly once
+        assert woke["n"] == 1       # WoL sent before the retry
+
+    async def test_gives_up_after_max_attempts(self, monkeypatch):
+        attempts = {"n": 0}
+
+        def always_fail():
+            attempts["n"] += 1
+            raise OSError("No route to host")
+
+        monkeypatch.setattr(server, "get_tv", always_fail)
+        monkeypatch.setattr(server, "_wake_tv", lambda: None)
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0)
+        monkeypatch.setattr(server, "TV_CONNECT_ATTEMPTS", 3)
+
+        with pytest.raises(OSError):
+            await server._tv_op(lambda art: art.supported())
+        assert attempts["n"] == 3
+
+    async def test_definitive_response_error_is_not_retried(self, monkeypatch):
+        """A ResponseError means the TV answered with a verdict (e.g. matte
+        '-10') — retrying is pointless and could duplicate work."""
+        attempts = {"n": 0}
+
+        def get_tv():
+            attempts["n"] += 1
+            tv = _ok_tv()
+            tv.art.return_value.upload.side_effect = ResponseError("send_image -10")
+            return tv
+
+        woke = {"n": 0}
+        monkeypatch.setattr(server, "get_tv", get_tv)
+        monkeypatch.setattr(server, "_wake_tv", lambda: woke.__setitem__("n", woke["n"] + 1))
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0)
+
+        with pytest.raises(ResponseError):
+            await server._tv_op(lambda art: art.upload(b"x"))
+        assert attempts["n"] == 1   # not retried
+        assert woke["n"] == 0       # no WoL on a definitive error
+
+    async def test_single_attempt_mode_does_not_retry(self, monkeypatch):
+        """Uploads pass attempts=1 so a lost response can't trigger a duplicate."""
+        attempts = {"n": 0}
+
+        def always_fail():
+            attempts["n"] += 1
+            raise OSError("connection reset")
+
+        monkeypatch.setattr(server, "get_tv", always_fail)
+        monkeypatch.setattr(server, "_wake_tv", lambda: None)
+
+        with pytest.raises(OSError):
+            await server._tv_op(lambda art: art.upload(b"x"), attempts=1)
+        assert attempts["n"] == 1
+
+
+class TestWakeOnLan:
+    def test_builds_and_sends_magic_packet(self, monkeypatch):
+        sent = []
+
+        class FakeSock:
+            def setsockopt(self, *a):
+                pass
+
+            def sendto(self, data, addr):
+                sent.append((data, addr))
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(server.socket, "socket", lambda *a, **k: FakeSock())
+        monkeypatch.setattr(server, "TV_MAC", "a4:30:7a:61:7a:e4")
+        monkeypatch.setattr(server, "TV_IP", "192.168.1.50")
+
+        server._wake_tv()
+
+        assert sent, "no WoL packet was sent"
+        data, _addr = sent[0]
+        assert len(data) == 102            # 6x 0xFF + 16x 6-byte MAC
+        assert data[:6] == b"\xff" * 6
+        assert data[6:12] == bytes.fromhex("a4307a617ae4")
+
+    def test_no_mac_is_noop(self, monkeypatch):
+        called = {"n": 0}
+        monkeypatch.setattr(server.socket, "socket", lambda *a, **k: called.__setitem__("n", called["n"] + 1))
+        monkeypatch.setattr(server, "TV_MAC", "")
+        server._wake_tv()
+        assert called["n"] == 0

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,52 @@
+"""Tests for the /api/upload endpoint.
+
+Regression coverage for the upload path, which had no tests — a size-limit
+change (commit c96df06) replaced ``await file.read()`` with
+``async for chunk in file`` which raises ``TypeError`` on a Starlette
+``UploadFile`` (it is not async-iterable), breaking every upload.
+"""
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+
+def _image_bytes(fmt: str = "PNG", size: tuple[int, int] = (32, 32)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, (12, 34, 56)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestUpload:
+    async def test_upload_reads_file_and_pushes_to_tv(self, client, mock_tv):
+        """A normal upload streams the file and reaches the TV (regression:
+        the streaming read used to crash with a TypeError)."""
+        mock_tv.upload.return_value = "MY_F0001"
+
+        resp = await client.post(
+            "/api/upload",
+            files={"file": ("art.png", _image_bytes(), "image/png")},
+            data={"matte": "none", "filename": "Test Art"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["content_id"] == "MY_F0001"
+        assert body["title"] == "Test Art"
+        assert mock_tv.upload.called
+
+    async def test_upload_enforces_size_limit(self, client, mock_tv, monkeypatch):
+        """The 50 MB cap (the reason the streaming read was introduced) still
+        works: an oversized upload is rejected with 413."""
+        monkeypatch.setattr("server.MAX_UPLOAD_BYTES", 8)  # smaller than any real image
+
+        resp = await client.post(
+            "/api/upload",
+            files={"file": ("big.png", _image_bytes(), "image/png")},
+            data={"matte": "none"},
+        )
+
+        assert resp.status_code == 413
+        assert not mock_tv.upload.called


### PR DESCRIPTION
> **Stacked on #44.** That upload fix is included in this branch's history, so the diff currently shows it too — review/merge #44 first and this will reduce to just the changes below.

## Why

Two things made talking to the Frame fragile:

1. **One slow TV call froze the whole app.** The blocking `samsungtvws` calls ran directly on the event loop inside `async` handlers, so a slow upload — or a TV that paused mid-call — made *every* request hang, including the page load.
2. **A single hiccup wedged the TV permanently.** A connection that hung held the TV lock and never released it, so every later request (including the "is the TV there?" check) queued behind it and timed out — surfacing as **"TV went to sleep"** until the server was restarted. The Frame regularly accepts the TCP socket *without* answering the art-mode handshake (busy with its on-screen menu, or mid sleep/wake), which is exactly what triggers this.

## What

- **Off the event loop:** every TV call now goes through one `_tv_op(fn)` helper that runs the blocking work in a worker thread, serialized by the existing `_tv_lock`. The loop stays free; a slow upload no longer freezes the app.
- **Hard per-attempt timeout:** a hung call raises and *releases the lock* instead of wedging all TV access until restart.
- **Wake-on-LAN + retry:** on a connection failure Docent sends a WoL magic packet (new `DOCENT_TV_MAC`) and retries, rather than giving up after one attempt. Uploads use a single attempt (no duplicate risk); a definitive `ResponseError` (e.g. the matte `-10`) is never retried.
- **Auto-reload off by default:** `main()` ran uvicorn with `reload=True`, but the server writes its data into the watched directory — so a normal upload tripped a reload that restarted the server mid-write. Now opt-in via `DOCENT_RELOAD=1`.

## Config (documented in README)

`DOCENT_TV_MAC`, `DOCENT_TV_ATTEMPTS` (3), `DOCENT_TV_RETRY_DELAY` (2), `DOCENT_RELOAD`, and `DOCENT_TV_TIMEOUT` default lowered 15 → 10. All optional — behaviour is unchanged when unset, apart from the reload default.

## Tests

`tests/test_tv_reliability.py` covers retry-then-succeed + WoL, give-up-after-max-attempts, no-retry-on-`ResponseError`, single-attempt mode, and the WoL packet format. Full suite: **81 passed**.

---

### A note from a happy user 🙂

Full disclosure, same as #44: this was written with AI assistance (Claude Code), out of fixing my own Frame setup — I wanted to contribute it back rather than keep it local.

Docent finally made this click for me. **In ~7 years I've never gotten images onto my Frame this easily.** I really love it now. Thanks for the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
