### PR TITLE
fix: non-blocking background prefetch for thumbnail fallback (#67)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2872,6 +2872,11 @@
       }
       const BATCH = 20;
       const TIMEOUT_MS = 30000;
+      // When the server is prefetching thumbnails in the background
+      // (fallback mode), allow more retries with shorter delays so the
+      // client picks up cached results as they become available.
+      const MAX_ATTEMPTS = _thumbFallbackSeen ? 8 : 3;
+      const retryDelay = (a) => _thumbFallbackSeen ? 3000 : 2000 * (a + 1);
       for (let i = 0; i < ids.length; i += BATCH) {
         const batch = ids.slice(i, i + BATCH);
         const controller = new AbortController();
@@ -2896,8 +2901,8 @@
           if (_thumbFallbackSeen) _updateThumbProgress();
           // Retry missing IDs returned by the server
           const stillMissing = (data.missing || []).filter(id => !thumbCache[id]);
-          if (stillMissing.length && attempt < 2) {
-            setTimeout(() => loadThumbnailBatch(stillMissing, attempt + 1), 2000 * (attempt + 1));
+          if (stillMissing.length && attempt + 1 < MAX_ATTEMPTS) {
+            setTimeout(() => loadThumbnailBatch(stillMissing, attempt + 1), retryDelay(attempt));
           } else {
             // Final attempt exhausted — mark failures as resolved for progress
             for (const id of stillMissing) {
@@ -2908,9 +2913,9 @@
           }
         } catch {
           clearTimeout(timer);
-          if (attempt < 2) {
+          if (attempt + 1 < MAX_ATTEMPTS) {
             const retryIds = batch.filter(id => !thumbCache[id]);
-            setTimeout(() => loadThumbnailBatch(retryIds, attempt + 1), 2000 * (attempt + 1));
+            setTimeout(() => loadThumbnailBatch(retryIds, attempt + 1), retryDelay(attempt));
           } else {
             // Final attempt exhausted — mark failures as resolved for progress
             for (const id of batch) {

--- a/index.html
+++ b/index.html
@@ -2873,8 +2873,9 @@
       const BATCH = 20;
       const TIMEOUT_MS = 30000;
       // When the server is prefetching thumbnails in the background
-      // (fallback mode), allow more retries with shorter delays so the
-      // client picks up cached results as they become available.
+      // (fallback mode), allow more retries with a fixed 3s interval so
+      // the client picks up cached results as they become available.
+      // Normal mode uses escalating backoff (2s, 4s, 6s).
       const MAX_ATTEMPTS = _thumbFallbackSeen ? 8 : 3;
       const retryDelay = (a) => _thumbFallbackSeen ? 3000 : 2000 * (a + 1);
       for (let i = 0; i < ids.length; i += BATCH) {

--- a/server.py
+++ b/server.py
@@ -461,6 +461,25 @@ async def get_thumbnail(content_id: str):
     return Response(content=bytes(data), media_type="image/jpeg")
 
 
+# Background thumbnail prefetch — tracks IDs already being fetched so
+# concurrent/retry requests don't spawn duplicate work.
+_thumb_prefetch_in_progress: set[str] = set()
+
+
+async def _prefetch_thumbnails(content_ids: list[str]) -> None:
+    """Fetch thumbnails individually in the background and cache to disk."""
+    for cid in content_ids:
+        try:
+            data = await _tv_op(lambda art, _cid=cid: art.get_thumbnail(_cid))
+            if data:
+                _save_thumbnail(cid, data)
+                log.debug("Background prefetch cached thumbnail for %s", cid)
+        except Exception:
+            log.debug("Background prefetch failed for %s", cid)
+        finally:
+            _thumb_prefetch_in_progress.discard(cid)
+
+
 @app.post("/api/thumbnails")
 async def get_thumbnails_batch(body: dict):
     content_ids = body.get("content_ids", [])
@@ -490,16 +509,16 @@ async def get_thumbnails_batch(body: dict):
         except Exception as e:
             log.warning("Batch thumbnail fetch failed, falling back to individual: %s", e)
             fallback = True
-            for cid in missing:
-                if cid in encoded:
-                    continue
-                try:
-                    data = await _tv_op(lambda art, _cid=cid: art.get_thumbnail(_cid))
-                    if data:
-                        _save_thumbnail(cid, data)
-                        encoded[cid] = base64.b64encode(bytes(data)).decode()
-                except Exception:
-                    log.debug("Could not fetch thumbnail for %s", cid)
+            # Instead of blocking the response with 20+ individual TV calls,
+            # return immediately and prefetch the missing thumbnails in the
+            # background.  The client will retry and find them cached on disk.
+            to_prefetch = [
+                cid for cid in missing
+                if cid not in encoded and cid not in _thumb_prefetch_in_progress
+            ]
+            if to_prefetch:
+                _thumb_prefetch_in_progress.update(to_prefetch)
+                asyncio.create_task(_prefetch_thumbnails(to_prefetch))
 
     still_missing = [c for c in missing if c not in encoded]
     return {"thumbnails": encoded, "missing": still_missing, "fallback": fallback}

--- a/server.py
+++ b/server.py
@@ -521,7 +521,7 @@ async def get_thumbnails_batch(body: dict):
                         encoded[cid] = base64.b64encode(bytes(data)).decode()
                         break
         except Exception as e:
-            log.warning("Batch thumbnail fetch failed, falling back to individual: %s", e)
+            log.warning("Batch thumbnail fetch failed, scheduling background prefetch: %s", e)
             fallback = True
             # Instead of blocking the response with 20+ individual TV calls,
             # return immediately and prefetch the missing thumbnails in the

--- a/server.py
+++ b/server.py
@@ -88,6 +88,8 @@ _current_id_cache: str | None = None
 _tv_lock = asyncio.Lock()
 _tv_conn: SamsungTVWS | None = None
 _tv_art = None
+_tv_last_used: float = 0
+TV_CONN_MAX_IDLE = 30  # seconds — proactively reconnect after this idle time
 _meta_lock = asyncio.Lock()
 _collections_lock = asyncio.Lock()
 _config_lock = asyncio.Lock()
@@ -122,15 +124,24 @@ def art_connection(tv: SamsungTVWS):
 def _ensure_tv_connection():
     """Return the current art connection, creating one if needed.
 
-    Must only be called while ``_tv_lock`` is held.
+    Must only be called while ``_tv_lock`` is held.  If the connection
+    has been idle longer than ``TV_CONN_MAX_IDLE`` seconds it is
+    proactively closed and reopened — Samsung Frame WebSockets go
+    stale after ~30-60 s of inactivity, leading to BrokenPipeError.
     """
-    global _tv_conn, _tv_art
+    global _tv_conn, _tv_art, _tv_last_used
     if _tv_art is not None:
-        return _tv_art
+        idle = time.monotonic() - _tv_last_used
+        if idle > TV_CONN_MAX_IDLE:
+            log.debug("TV connection idle for %.0fs — reconnecting", idle)
+            _close_tv_connection()
+        else:
+            return _tv_art
     tv = get_tv()
     art = art_connection(tv)
     _tv_conn = tv
     _tv_art = art
+    _tv_last_used = time.monotonic()
     log.debug("TV connection opened")
     return art
 
@@ -206,7 +217,10 @@ async def _tv_op(fn, *, attempts: int = TV_CONNECT_ATTEMPTS, timeout: float | No
     for attempt in range(attempts):
         async with _tv_lock:
             try:
-                return await asyncio.wait_for(asyncio.to_thread(_job), timeout=timeout)
+                result = await asyncio.wait_for(asyncio.to_thread(_job), timeout=timeout)
+                global _tv_last_used
+                _tv_last_used = time.monotonic()
+                return result
             except ResponseError:
                 raise  # TV answered with a definitive error — retrying won't help
             except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,8 @@ def tmp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_tv_conn", None)
     monkeypatch.setattr(server, "_tv_art", None)
     monkeypatch.setattr(server, "_nws_station_cache", {})
+    monkeypatch.setattr(server, "_thumb_prefetch_in_progress", set())
+    monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())
 
     return tmp_path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def tmp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_current_id_cache", None)
     monkeypatch.setattr(server, "_tv_conn", None)
     monkeypatch.setattr(server, "_tv_art", None)
+    monkeypatch.setattr(server, "_tv_last_used", 0)
     monkeypatch.setattr(server, "_nws_station_cache", {})
     monkeypatch.setattr(server, "_thumb_prefetch_in_progress", set())
     monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -390,13 +390,14 @@ class TestThumbnailBatchFallback:
         # prefetched in the background and served from cache on retry.
         assert data["missing"] == ["ART001", "ART002"]
 
-        # Give the background task time to run
+        # Poll for background prefetch to complete (avoids fixed-sleep flakiness)
         import asyncio
-        await asyncio.sleep(0.2)
-
-        # Now a retry request should find them cached on disk
-        resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
-        data2 = resp2.json()
+        for _ in range(20):
+            await asyncio.sleep(0.1)
+            resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
+            data2 = resp2.json()
+            if "ART001" in data2["thumbnails"] and "ART002" in data2["thumbnails"]:
+                break
         assert "ART001" in data2["thumbnails"]
         assert "ART002" in data2["thumbnails"]
         assert data2["missing"] == []
@@ -419,13 +420,15 @@ class TestThumbnailBatchFallback:
         assert data["fallback"] is True
         assert data["missing"] == ["ART001", "ART002"]
 
-        # Give the background task time to run
+        # Poll for background prefetch to complete (avoids fixed-sleep flakiness)
         import asyncio
-        await asyncio.sleep(0.2)
-
-        # Retry — ART001 was cached by background task, ART002 still fails
-        resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
-        data2 = resp2.json()
+        for _ in range(20):
+            await asyncio.sleep(0.1)
+            resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
+            data2 = resp2.json()
+            if "ART001" in data2["thumbnails"]:
+                break
+        # ART001 was cached by background task, ART002 still fails
         assert "ART001" in data2["thumbnails"]
         assert "ART002" not in data2["thumbnails"]
         assert data2["missing"] == ["ART002"]

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -376,8 +376,9 @@ class TestThumbnailBatchFallback:
         assert "ART001" in data["thumbnails"]
         assert data["missing"] == []
 
-    async def test_batch_failure_falls_back_to_individual(self, client, mock_tv, tmp_data_dir):
-        """When get_thumbnail_list fails, should fall back to individual get_thumbnail."""
+    async def test_batch_failure_falls_back_to_background_prefetch(self, client, mock_tv, tmp_data_dir):
+        """When get_thumbnail_list fails, response returns immediately with
+        fallback=True and missing IDs; a background task prefetches them."""
         mock_tv.get_thumbnail_list.side_effect = Exception("socket closed")
         mock_tv.get_thumbnail.return_value = b"\xff\xd8\xff\xe0thumb-individual"
 
@@ -385,12 +386,24 @@ class TestThumbnailBatchFallback:
         assert resp.status_code == 200
         data = resp.json()
         assert data["fallback"] is True
-        assert "ART001" in data["thumbnails"]
-        assert "ART002" in data["thumbnails"]
-        assert data["missing"] == []
+        # Thumbnails are NOT in the immediate response — they'll be
+        # prefetched in the background and served from cache on retry.
+        assert data["missing"] == ["ART001", "ART002"]
+
+        # Give the background task time to run
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        # Now a retry request should find them cached on disk
+        resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
+        data2 = resp2.json()
+        assert "ART001" in data2["thumbnails"]
+        assert "ART002" in data2["thumbnails"]
+        assert data2["missing"] == []
 
     async def test_partial_fallback_results(self, client, mock_tv, tmp_data_dir):
-        """When some individual fetches fail, return partial results."""
+        """When batch fails, missing IDs are prefetched in background.
+        IDs that the TV can't fetch remain missing even after retry."""
         mock_tv.get_thumbnail_list.side_effect = Exception("socket closed")
 
         def _get_thumb(cid):
@@ -404,9 +417,18 @@ class TestThumbnailBatchFallback:
         assert resp.status_code == 200
         data = resp.json()
         assert data["fallback"] is True
-        assert "ART001" in data["thumbnails"]
-        assert "ART002" not in data["thumbnails"]
-        assert data["missing"] == ["ART002"]
+        assert data["missing"] == ["ART001", "ART002"]
+
+        # Give the background task time to run
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        # Retry — ART001 was cached by background task, ART002 still fails
+        resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
+        data2 = resp2.json()
+        assert "ART001" in data2["thumbnails"]
+        assert "ART002" not in data2["thumbnails"]
+        assert data2["missing"] == ["ART002"]
 
     async def test_cached_ids_skip_tv(self, client, mock_tv, tmp_data_dir):
         """Cached thumbnails should be returned without hitting the TV."""

--- a/tests/test_issue67_diagnosis.py
+++ b/tests/test_issue67_diagnosis.py
@@ -6,6 +6,7 @@ failures after PRs #68 and #69 were merged.
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from unittest.mock import MagicMock, call
 
@@ -164,10 +165,10 @@ class TestTvOpTimeoutBehavior:
         monkeypatch.setattr(server, "_close_tv_connection", tracking_close)
 
         # Simulate a call that hangs (like a stuck D2D recv)
+        cancel = threading.Event()
         def hanging_fn(art):
-            import threading
-            # Simulate the D2D socket blocking on recv for a long time
-            time.sleep(10)
+            # Block until cancelled — avoids a fixed sleep that stalls the suite
+            cancel.wait(timeout=2)
             return {}
 
         ensure_called = []
@@ -181,9 +182,8 @@ class TestTvOpTimeoutBehavior:
 
         # _close_tv_connection WAS called (good)
         assert len(close_calls) == 1
-        # But the thread running hanging_fn is still alive — it will keep
-        # the D2D socket open for 10 more seconds. We can't test this
-        # directly but we confirm the cleanup path runs.
+        # Release the worker thread so it doesn't linger after the test
+        cancel.set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue67_diagnosis.py
+++ b/tests/test_issue67_diagnosis.py
@@ -1,0 +1,486 @@
+"""Diagnostic tests for issue #67 — TV thumbnail failures on large catalogs.
+
+These tests confirm the root causes of the remaining thumbnail loading
+failures after PRs #68 and #69 were merged.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock, call
+
+import pytest
+
+import server
+from samsungtvws.exceptions import ConnectionFailure
+
+
+# ---------------------------------------------------------------------------
+# 1. Verify the get_thumbnail_list key format and server-side matching
+# ---------------------------------------------------------------------------
+
+class TestThumbnailKeyMatching:
+    """The samsungtvws library returns thumbnail dict keys as
+    '{fileID}.{fileType}' (e.g. 'MY_F0379.jpg'). Confirm the server's
+    startswith() matching handles this correctly.
+    """
+
+    async def test_matching_works_with_extension_suffix(self, client, mock_tv, tmp_data_dir):
+        """The TV returns keys like 'ART001.jpg' — startswith('ART001') should match."""
+        mock_tv.get_thumbnail_list.return_value = {
+            "ART001.jpg": bytearray(b"\xff\xd8\xff\xe0thumb1"),
+            "ART002.jpg": bytearray(b"\xff\xd8\xff\xe0thumb2"),
+        }
+        resp = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
+        data = resp.json()
+        assert "ART001" in data["thumbnails"], "Server should match 'ART001.jpg' to 'ART001'"
+        assert "ART002" in data["thumbnails"], "Server should match 'ART002.jpg' to 'ART002'"
+        assert data["missing"] == []
+
+    async def test_matching_fails_when_key_doesnt_start_with_content_id(self, client, mock_tv, tmp_data_dir):
+        """If the TV returns an unexpected key format, matching silently drops the data."""
+        mock_tv.get_thumbnail_list.return_value = {
+            # Hypothetical: TV returns a different identifier
+            "thumb_ART001.jpg": bytearray(b"\xff\xd8\xff\xe0thumb1"),
+        }
+        resp = await client.post("/api/thumbnails", json={"content_ids": ["ART001"]})
+        data = resp.json()
+        # Key does NOT start with 'ART001', so matching fails
+        assert "ART001" not in data["thumbnails"]
+        assert "ART001" in data["missing"]
+        # The fallback flag is False because get_thumbnail_list didn't throw
+        assert data["fallback"] is False
+
+    async def test_batch_success_returns_thumbnails_not_cached_to_disk_on_mismatch(
+        self, client, mock_tv, tmp_data_dir
+    ):
+        """When matching fails, thumbnails are NOT cached to disk either —
+        so 'click to retry' won't find them in cache.
+        """
+        mock_tv.get_thumbnail_list.return_value = {
+            "thumb_ART001.jpg": bytearray(b"\xff\xd8\xff\xe0thumb1"),
+        }
+        await client.post("/api/thumbnails", json={"content_ids": ["ART001"]})
+        thumb_file = server.THUMB_DIR / "ART001.jpg"
+        assert not thumb_file.exists(), "Mismatched key should not be cached to disk"
+
+
+# ---------------------------------------------------------------------------
+# 2. Individual fallback flooding — what happens with 20 IDs failing
+# ---------------------------------------------------------------------------
+
+class TestIndividualFallbackBehavior:
+    """When get_thumbnail_list raises an exception, the server falls back to
+    individual get_thumbnail calls. With 20 IDs per batch, that's 20
+    sequential _tv_op calls — each acquiring the lock, potentially
+    reconnecting, and opening a D2D socket.
+    """
+
+    async def test_fallback_makes_n_individual_calls(self, client, mock_tv, tmp_data_dir):
+        """Each missing ID in fallback triggers a separate _tv_op call."""
+        mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
+        mock_tv.get_thumbnail.return_value = bytearray(b"\xff\xd8\xff\xe0thumb")
+
+        ids = [f"ART{i:03d}" for i in range(20)]
+        resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data = resp.json()
+        assert data["fallback"] is True
+        # The server made 20 individual get_thumbnail calls
+        assert mock_tv.get_thumbnail.call_count == 20
+
+    async def test_fallback_cascading_failures(self, client, mock_tv, tmp_data_dir):
+        """When the TV is unstable, individual fallback calls also fail,
+        compounding the problem.
+        """
+        mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
+        # First few succeed, then the TV gives up
+        call_count = 0
+        def flaky_get_thumbnail(cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                return bytearray(b"\xff\xd8\xff\xe0thumb")
+            raise ConnectionFailure({"reason": "socket closed"})
+
+        mock_tv.get_thumbnail.side_effect = flaky_get_thumbnail
+
+        ids = [f"ART{i:03d}" for i in range(10)]
+        resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data = resp.json()
+        assert data["fallback"] is True
+        # Only 3 thumbnails succeeded
+        assert len(data["thumbnails"]) == 3
+        # 7 are still missing
+        assert len(data["missing"]) == 7
+
+    async def test_fallback_total_time_with_retries(self, client, mock_tv, tmp_data_dir, monkeypatch):
+        """Measure wall-clock time: individual fallback for N IDs where each
+        _tv_op fails and retries 3 times. Each retry has a 2s delay.
+
+        For 5 IDs with 3 attempts each = 15 _tv_op calls, with 2 retries
+        per call sleeping 2s each = potentially 5 * 2 * 2 = 20 seconds of
+        just sleeping. This is why the UI freezes.
+        """
+        # Patch retry delay to be fast for testing
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
+
+        mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
+        mock_tv.get_thumbnail.side_effect = ConnectionFailure({"reason": "socket closed"})
+
+        ids = [f"ART{i:03d}" for i in range(5)]
+        start = time.monotonic()
+        resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        elapsed = time.monotonic() - start
+
+        data = resp.json()
+        assert data["fallback"] is True
+        assert len(data["missing"]) == 5
+        # Even with 0.01s retry delay, 5 IDs * 3 attempts each means
+        # 5 * 2 retries * 0.01s = 0.1s minimum just from retry delays
+        # At the real 2s delay this would be 5 * 2 * 2 = 20 seconds
+        # for a SINGLE batch of 5 thumbnails.
+
+
+# ---------------------------------------------------------------------------
+# 3. _tv_op timeout vs D2D socket cleanup
+# ---------------------------------------------------------------------------
+
+class TestTvOpTimeoutBehavior:
+    """When _tv_op times out, the D2D socket opened by get_thumbnail_list
+    is NOT properly cleaned up because the thread is still blocked on recv.
+    """
+
+    async def test_timeout_closes_main_connection(self, monkeypatch):
+        """After a timeout, _close_tv_connection is called, but the D2D socket
+        opened inside get_thumbnail_list is still alive in the thread.
+        """
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
+
+        close_calls = []
+        original_close = server._close_tv_connection
+        def tracking_close():
+            close_calls.append(time.monotonic())
+            original_close()
+        monkeypatch.setattr(server, "_close_tv_connection", tracking_close)
+
+        # Simulate a call that hangs (like a stuck D2D recv)
+        def hanging_fn(art):
+            import threading
+            # Simulate the D2D socket blocking on recv for a long time
+            time.sleep(10)
+            return {}
+
+        ensure_called = []
+        def mock_ensure():
+            ensure_called.append(True)
+            return MagicMock()
+        monkeypatch.setattr(server, "_ensure_tv_connection", mock_ensure)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await server._tv_op(hanging_fn, attempts=1, timeout=0.1)
+
+        # _close_tv_connection WAS called (good)
+        assert len(close_calls) == 1
+        # But the thread running hanging_fn is still alive — it will keep
+        # the D2D socket open for 10 more seconds. We can't test this
+        # directly but we confirm the cleanup path runs.
+
+
+# ---------------------------------------------------------------------------
+# 4. Concurrent request serialization under load
+# ---------------------------------------------------------------------------
+
+class TestConcurrentTvOps:
+    """Multiple thumbnail batch requests arriving concurrently should be
+    serialized by _tv_lock, but the individual fallback creates many
+    sequential lock acquisitions per batch, starving other operations.
+    """
+
+    async def test_individual_fallback_blocks_other_ops(self, monkeypatch):
+        """When individual fallback is processing 20 IDs, other TV ops
+        (select, matte, info) are blocked until ALL 20 complete.
+        """
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
+        # Fresh lock to avoid cross-test contamination
+        monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())
+        op_log = []
+
+        mock_art = MagicMock()
+        def mock_ensure():
+            return mock_art
+        monkeypatch.setattr(server, "_ensure_tv_connection", mock_ensure)
+        monkeypatch.setattr(server, "_close_tv_connection", lambda: None)
+
+        async def slow_batch():
+            """Simulate the individual fallback: each get_thumbnail takes 0.5s"""
+            def batch_fn(art):
+                time.sleep(0.05)  # Simulates D2D transfer time per thumbnail
+                op_log.append(("thumb", time.monotonic()))
+                return bytearray(b"\xff\xd8thumb")
+
+            for i in range(10):
+                await server._tv_op(batch_fn, attempts=1, timeout=5)
+
+        async def quick_select():
+            """A user clicking 'Display on Frame' during thumbnail loading"""
+            await asyncio.sleep(0.02)  # Small delay to ensure batch starts first
+            start = time.monotonic()
+            def select_fn(art):
+                op_log.append(("select", time.monotonic()))
+                return True
+            await server._tv_op(select_fn, attempts=1, timeout=5)
+            return time.monotonic() - start
+
+        batch_task = asyncio.create_task(slow_batch())
+        select_time = await quick_select()
+        await batch_task
+
+        # The select op had to wait for at least some of the batch ops
+        select_entry = [t for op, t in op_log if op == "select"]
+        first_thumb = [t for op, t in op_log if op == "thumb"][0]
+        assert len(select_entry) == 1
+        # Select was blocked by at least one thumbnail op
+        assert select_entry[0] > first_thumb, (
+            "Select should have been delayed by the thumbnail fallback lock contention"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Real-world scenario: 524 artworks, 26 batches of 20
+# ---------------------------------------------------------------------------
+
+class TestLargeCatalogScenario:
+    """Simulate the user's 524-artwork catalog to measure the scale of
+    lock contention and connection attempts.
+    """
+
+    async def test_526_artworks_connection_count(self, client, mock_tv, tmp_data_dir, monkeypatch):
+        """With 524 artworks, the frontend sends 26 batches of 20 + 1 batch of 4.
+        If ALL fail and trigger individual fallback, that's up to
+        524 individual _tv_op calls, each with 3 attempts = 1,572 connection attempts.
+        """
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.001)
+
+        batch_call_count = 0
+        individual_call_count = 0
+
+        def fail_batch(ids):
+            nonlocal batch_call_count
+            batch_call_count += 1
+            raise ConnectionFailure({"reason": "socket closed"})
+
+        def fail_individual(cid):
+            nonlocal individual_call_count
+            individual_call_count += 1
+            raise ConnectionFailure({"reason": "socket closed"})
+
+        mock_tv.get_thumbnail_list.side_effect = fail_batch
+        mock_tv.get_thumbnail.side_effect = fail_individual
+
+        # Simulate ONE batch of 20 (what the frontend sends)
+        ids = [f"ART{i:04d}" for i in range(20)]
+        resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data = resp.json()
+
+        assert data["fallback"] is True
+        assert len(data["missing"]) == 20
+        # With 3 attempts per _tv_op:
+        # 1 batch call (3 attempts) + 20 individual calls (3 attempts each)
+        # = 3 + 60 = 63 connection attempts for ONE batch of 20
+        # For 524 artworks that's 26 batches × 63 = 1,638 connection attempts
+        total_attempts = batch_call_count + individual_call_count
+        # Each failing _tv_op with 3 attempts means 3 calls to get_thumbnail
+        # per content_id, so individual_call_count = 20 * 3 = 60
+        assert individual_call_count >= 20, (
+            f"Expected at least 20 individual calls, got {individual_call_count}. "
+            f"Each call uses 3 retry attempts internally."
+        )
+
+    async def test_cached_thumbnails_skip_tv_entirely(self, client, mock_tv, tmp_data_dir):
+        """Confirm that disk-cached thumbnails are served without touching the TV.
+        This is why 'click to retry' works instantly after an earlier partial success.
+        """
+        # Pre-populate disk cache
+        for i in range(5):
+            (server.THUMB_DIR / f"ART{i:03d}.jpg").write_bytes(b"\xff\xd8\xff\xe0cached")
+
+        resp = await client.post(
+            "/api/thumbnails",
+            json={"content_ids": [f"ART{i:03d}" for i in range(5)]},
+        )
+        data = resp.json()
+        assert len(data["thumbnails"]) == 5
+        assert data["missing"] == []
+        assert data["fallback"] is False
+        # The TV was NEVER contacted
+        mock_tv.get_thumbnail_list.assert_not_called()
+        mock_tv.get_thumbnail.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 6. Client timeout race — the actual root cause of infinite retry loops
+# ---------------------------------------------------------------------------
+
+class TestClientTimeoutRace:
+    """The frontend uses a 30s AbortController timeout on /api/thumbnails.
+    When the server-side individual fallback runs for a batch of 20
+    failing IDs, the response takes far longer than 30s.  The frontend
+    aborts, never sees the response, and retries — creating an infinite
+    loop where the server IS caching thumbnails to disk but the client
+    never receives confirmation.
+
+    This is why Nitrowolf sees:
+      - "POST /api/thumbnails 200 53.48s" in server logs
+      - Progress bar never appears (response aborted before `fallback: true` received)
+      - "Tap to retry" → instant thumbnail (disk cache populated by the aborted request)
+    """
+
+    FRONTEND_TIMEOUT_MS = 30_000  # from index.html loadThumbnailBatch
+
+    def _calculate_worst_case_fallback_time_ms(
+        self,
+        n_ids: int,
+        attempts: int = 3,
+        timeout_s: float = 18,    # TV_TIMEOUT(10) + 8
+        retry_delay_s: float = 2,
+    ) -> float:
+        """Calculate worst-case server response time for individual fallback.
+
+        For each ID:
+          - `attempts` tries, each bounded by `timeout_s`
+          - (attempts - 1) retry delays of `retry_delay_s`
+          Total per ID = attempts * timeout_s + (attempts - 1) * retry_delay_s
+
+        These are sequential because each _tv_op acquires _tv_lock.
+        """
+        per_id_s = attempts * timeout_s + (attempts - 1) * retry_delay_s
+        return n_ids * per_id_s * 1000  # convert to ms
+
+    def test_worst_case_exceeds_client_timeout(self):
+        """Even with just 1 failing ID, worst-case time can exceed 30s.
+        With 20 IDs (the batch size), it's catastrophically over.
+        """
+        # 1 ID, all 3 attempts timeout at 18s each + 2 retry delays of 2s
+        one_id_worst_ms = self._calculate_worst_case_fallback_time_ms(1)
+        # 1 * (3 * 18 + 2 * 2) * 1000 = 58,000ms = 58s
+        assert one_id_worst_ms == 58_000, f"Expected 58s, got {one_id_worst_ms}ms"
+        assert one_id_worst_ms > self.FRONTEND_TIMEOUT_MS, (
+            f"Even 1 failing ID ({one_id_worst_ms}ms) exceeds "
+            f"client timeout ({self.FRONTEND_TIMEOUT_MS}ms)"
+        )
+
+        # 20 IDs (one batch) = 20 * 58s = 1,160s ≈ 19 minutes
+        batch_worst_ms = self._calculate_worst_case_fallback_time_ms(20)
+        assert batch_worst_ms == 1_160_000
+        assert batch_worst_ms > self.FRONTEND_TIMEOUT_MS * 38, (
+            "A single batch's fallback can take 38× the client timeout"
+        )
+
+    def test_realistic_case_still_exceeds_client_timeout(self):
+        """Even with optimistic timing (1s per successful call), a batch where
+        half the IDs succeed quickly and half fail once still exceeds 30s.
+        """
+        # 10 IDs succeed in 1s each = 10s
+        # 10 IDs fail once, succeed on retry: per ID = 1s (fail) + 2s (delay) + 1s (succeed) = 4s
+        # Total = 10 + 40 = 50s > 30s
+        fast_ids_ms = 10 * 1_000
+        slow_ids_ms = 10 * 4_000  # fail once, succeed on retry
+        total_ms = fast_ids_ms + slow_ids_ms
+        assert total_ms == 50_000
+        assert total_ms > self.FRONTEND_TIMEOUT_MS, (
+            f"Realistic mixed scenario ({total_ms}ms) exceeds "
+            f"client timeout ({self.FRONTEND_TIMEOUT_MS}ms)"
+        )
+
+    async def test_server_caches_thumbnails_despite_client_timeout(
+        self, client, mock_tv, tmp_data_dir, monkeypatch
+    ):
+        """Even when the client would abort (simulated), the server still
+        saves thumbnails to disk. This explains why click-to-retry works.
+        """
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.001)
+        mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
+
+        call_idx = 0
+        def intermittent_thumbnail(cid):
+            nonlocal call_idx
+            call_idx += 1
+            # First 5 IDs succeed, rest fail
+            if call_idx <= 5:
+                return bytearray(b"\xff\xd8\xff\xe0thumb")
+            raise ConnectionFailure({"reason": "socket closed"})
+
+        mock_tv.get_thumbnail.side_effect = intermittent_thumbnail
+
+        ids = [f"ART{i:03d}" for i in range(10)]
+        # This request completes (in tests, no actual 30s timeout)
+        resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data = resp.json()
+
+        # Server returned 5 thumbnails in the response
+        assert len(data["thumbnails"]) == 5
+
+        # But crucially: those 5 are ALSO on disk
+        cached_count = sum(
+            1 for i in range(10)
+            if (server.THUMB_DIR / f"ART{i:03d}.jpg").exists()
+        )
+        assert cached_count == 5, (
+            "Server cached thumbnails to disk during fallback — "
+            "even if the client times out, a retry will find them in cache"
+        )
+
+        # Now simulate the retry — all 10 IDs requested again
+        mock_tv.get_thumbnail_list.reset_mock()
+        mock_tv.get_thumbnail.reset_mock()
+
+        resp2 = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data2 = resp2.json()
+        # The 5 cached IDs are served from disk without touching TV
+        assert len(data2["thumbnails"]) >= 5
+        # TV should NOT be called for the cached IDs
+        # (it may be called for the 5 missing ones)
+
+    def test_frontend_retry_creates_infinite_loop(self):
+        """Walk through the exact infinite loop scenario.
+
+        Timeline for 1 batch of 20 IDs where the TV is struggling:
+
+        t=0s:    Frontend sends POST /api/thumbnails {20 IDs}
+        t=0s:    Server tries get_thumbnail_list → fails after ~18s
+        t=18s:   Server starts individual fallback for 20 IDs
+        t=30s:   Frontend AbortController fires, request aborted
+                 Frontend schedules retry in 2s (attempt=1)
+        t=32s:   Frontend sends POST /api/thumbnails {20 IDs} again
+                 (server still processing previous request's fallback!)
+        t=53s:   Server finishes first request's fallback (status 200, but nobody reads it)
+                 Some thumbnails cached to disk
+        t=62s:   Frontend AbortController fires AGAIN on retry
+                 Frontend schedules retry in 4s (attempt=2, final)
+        t=66s:   Frontend sends final POST /api/thumbnails {20 IDs}
+        t=66s:   Server finds some in disk cache, tries TV for rest
+        t=96s:   Frontend AbortController fires, gives up → "Tap to retry"
+
+        Result: 3 server requests, ~96s elapsed, progress bar never shown,
+        most thumbnails actually cached to disk but frontend doesn't know.
+        """
+        # This is a documentation test — the assertions just verify the math
+        batch_attempt_time_s = 18  # get_thumbnail_list with 3 attempts, worst case
+        # After batch fails, individual fallback for 20 IDs
+        # Even if some succeed in 1s, a few timeouts blow past 30s
+        individual_fallback_time_s = 35  # conservative: some succeed, some timeout once
+        total_server_time_s = batch_attempt_time_s + individual_fallback_time_s
+
+        assert total_server_time_s > 30, "Server response exceeds client timeout"
+
+        # Frontend retries: attempt 0 (30s timeout), attempt 1 (30s), attempt 2 (30s)
+        # Each retry has a backoff delay: 2s, 4s
+        total_frontend_wall_time_s = 30 + 2 + 30 + 4 + 30
+        assert total_frontend_wall_time_s == 96, "User waits ~96s before seeing 'Tap to retry'"
+
+        # Meanwhile the server processes 3 overlapping requests
+        # (the lock serializes them, so they queue up)
+        server_requests = 3
+        assert server_requests * total_server_time_s > total_frontend_wall_time_s, (
+            "Server is still processing when the frontend gives up entirely"
+        )

--- a/tests/test_issue67_diagnosis.py
+++ b/tests/test_issue67_diagnosis.py
@@ -277,7 +277,7 @@ class TestLargeCatalogScenario:
     lock contention and connection attempts.
     """
 
-    async def test_526_artworks_connection_count(self, client, mock_tv, tmp_data_dir, monkeypatch):
+    async def test_524_artworks_connection_count(self, client, mock_tv, tmp_data_dir, monkeypatch):
         """With 524 artworks, the frontend sends 26 batches of 20 + 1 batch of 4.
         If ALL fail and trigger individual fallback, that's up to
         524 individual _tv_op calls, each with 3 attempts = 1,572 connection attempts.

--- a/tests/test_issue67_diagnosis.py
+++ b/tests/test_issue67_diagnosis.py
@@ -71,30 +71,49 @@ class TestThumbnailKeyMatching:
 # ---------------------------------------------------------------------------
 
 class TestIndividualFallbackBehavior:
-    """When get_thumbnail_list raises an exception, the server falls back to
-    individual get_thumbnail calls. With 20 IDs per batch, that's 20
-    sequential _tv_op calls — each acquiring the lock, potentially
-    reconnecting, and opening a D2D socket.
+    """When get_thumbnail_list raises an exception, the server now returns
+    immediately and prefetches missing thumbnails in a background task.
+    This breaks the timeout race that blocked Nitrowolf's UI.
     """
 
-    async def test_fallback_makes_n_individual_calls(self, client, mock_tv, tmp_data_dir):
-        """Each missing ID in fallback triggers a separate _tv_op call."""
+    async def test_fallback_returns_immediately_and_prefetches(self, client, mock_tv, tmp_data_dir, monkeypatch):
+        """Response returns fast with all IDs as missing; background task
+        fetches them individually and caches to disk."""
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
         mock_tv.get_thumbnail.return_value = bytearray(b"\xff\xd8\xff\xe0thumb")
 
         ids = [f"ART{i:03d}" for i in range(20)]
+        start = time.monotonic()
         resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        elapsed = time.monotonic() - start
         data = resp.json()
+
         assert data["fallback"] is True
-        # The server made 20 individual get_thumbnail calls
+        # Response returns FAST — no inline individual calls
+        assert elapsed < 2.0, f"Response took {elapsed:.2f}s, should be fast"
+        # All IDs are missing in the immediate response
+        assert len(data["missing"]) == 20
+        # No thumbnails inline (they're being prefetched)
+        assert len(data["thumbnails"]) == 0
+
+        # Give background task time to run
+        await asyncio.sleep(0.5)
+
+        # Now the background task should have cached them
+        resp2 = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data2 = resp2.json()
+        assert len(data2["thumbnails"]) == 20
+        assert data2["missing"] == []
+        # Background task made 20 individual get_thumbnail calls
         assert mock_tv.get_thumbnail.call_count == 20
 
-    async def test_fallback_cascading_failures(self, client, mock_tv, tmp_data_dir):
-        """When the TV is unstable, individual fallback calls also fail,
-        compounding the problem.
+    async def test_fallback_cascading_failures(self, client, mock_tv, tmp_data_dir, monkeypatch):
+        """When the TV is unstable, background prefetch caches what it can
+        and drops the rest.
         """
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
-        # First few succeed, then the TV gives up
         call_count = 0
         def flaky_get_thumbnail(cid):
             nonlocal call_count
@@ -109,20 +128,23 @@ class TestIndividualFallbackBehavior:
         resp = await client.post("/api/thumbnails", json={"content_ids": ids})
         data = resp.json()
         assert data["fallback"] is True
-        # Only 3 thumbnails succeeded
-        assert len(data["thumbnails"]) == 3
-        # 7 are still missing
-        assert len(data["missing"]) == 7
+        # Immediate response has all 10 as missing
+        assert len(data["missing"]) == 10
 
-    async def test_fallback_total_time_with_retries(self, client, mock_tv, tmp_data_dir, monkeypatch):
-        """Measure wall-clock time: individual fallback for N IDs where each
-        _tv_op fails and retries 3 times. Each retry has a 2s delay.
+        # Give background task time to finish
+        await asyncio.sleep(0.5)
 
-        For 5 IDs with 3 attempts each = 15 _tv_op calls, with 2 retries
-        per call sleeping 2s each = potentially 5 * 2 * 2 = 20 seconds of
-        just sleeping. This is why the UI freezes.
+        # Retry — only 3 were cached successfully
+        resp2 = await client.post("/api/thumbnails", json={"content_ids": ids})
+        data2 = resp2.json()
+        assert len(data2["thumbnails"]) == 3
+        assert len(data2["missing"]) == 7
+
+    async def test_fallback_response_time_is_bounded(self, client, mock_tv, tmp_data_dir, monkeypatch):
+        """The response returns in bounded time regardless of how many IDs
+        are missing or how slow the TV is. The old inline fallback would
+        take 5 × 2 retries × 2s = 20 seconds for just 5 IDs.
         """
-        # Patch retry delay to be fast for testing
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
 
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
@@ -136,10 +158,11 @@ class TestIndividualFallbackBehavior:
         data = resp.json()
         assert data["fallback"] is True
         assert len(data["missing"]) == 5
-        # Even with 0.01s retry delay, 5 IDs * 3 attempts each means
-        # 5 * 2 retries * 0.01s = 0.1s minimum just from retry delays
-        # At the real 2s delay this would be 5 * 2 * 2 = 20 seconds
-        # for a SINGLE batch of 5 thumbnails.
+        # Response is fast — no inline retry delays
+        assert elapsed < 2.0, (
+            f"Response took {elapsed:.2f}s — should be bounded by the initial "
+            f"get_thumbnail_list attempt only, not 20+ seconds of individual calls"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -258,42 +281,40 @@ class TestLargeCatalogScenario:
         """With 524 artworks, the frontend sends 26 batches of 20 + 1 batch of 4.
         If ALL fail and trigger individual fallback, that's up to
         524 individual _tv_op calls, each with 3 attempts = 1,572 connection attempts.
+
+        With the background prefetch fix, the response returns immediately
+        and the individual calls happen asynchronously.
         """
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.001)
 
         batch_call_count = 0
-        individual_call_count = 0
 
         def fail_batch(ids):
             nonlocal batch_call_count
             batch_call_count += 1
             raise ConnectionFailure({"reason": "socket closed"})
 
-        def fail_individual(cid):
-            nonlocal individual_call_count
-            individual_call_count += 1
-            raise ConnectionFailure({"reason": "socket closed"})
-
         mock_tv.get_thumbnail_list.side_effect = fail_batch
-        mock_tv.get_thumbnail.side_effect = fail_individual
+        mock_tv.get_thumbnail.side_effect = ConnectionFailure({"reason": "socket closed"})
 
         # Simulate ONE batch of 20 (what the frontend sends)
         ids = [f"ART{i:04d}" for i in range(20)]
+        start = time.monotonic()
         resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        elapsed = time.monotonic() - start
         data = resp.json()
 
         assert data["fallback"] is True
         assert len(data["missing"]) == 20
-        # With 3 attempts per _tv_op:
-        # 1 batch call (3 attempts) + 20 individual calls (3 attempts each)
-        # = 3 + 60 = 63 connection attempts for ONE batch of 20
-        # For 524 artworks that's 26 batches × 63 = 1,638 connection attempts
-        total_attempts = batch_call_count + individual_call_count
-        # Each failing _tv_op with 3 attempts means 3 calls to get_thumbnail
-        # per content_id, so individual_call_count = 20 * 3 = 60
-        assert individual_call_count >= 20, (
-            f"Expected at least 20 individual calls, got {individual_call_count}. "
-            f"Each call uses 3 retry attempts internally."
+        # Response returns fast — no inline individual calls
+        assert elapsed < 2.0, f"Response took {elapsed:.2f}s, should be bounded"
+
+        # Give background task time to attempt individual calls
+        await asyncio.sleep(0.5)
+
+        # Background task attempted individual calls (20 IDs × 3 attempts each)
+        assert mock_tv.get_thumbnail.call_count >= 20, (
+            f"Expected at least 20 background individual calls, got {mock_tv.get_thumbnail.call_count}"
         )
 
     async def test_cached_thumbnails_skip_tv_entirely(self, client, mock_tv, tmp_data_dir):
@@ -395,8 +416,9 @@ class TestClientTimeoutRace:
     async def test_server_caches_thumbnails_despite_client_timeout(
         self, client, mock_tv, tmp_data_dir, monkeypatch
     ):
-        """Even when the client would abort (simulated), the server still
-        saves thumbnails to disk. This explains why click-to-retry works.
+        """With background prefetch, the server responds immediately and
+        prefetches thumbnails in the background. The cached thumbnails
+        are available on retry. This eliminates the timeout race entirely.
         """
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.001)
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
@@ -413,21 +435,25 @@ class TestClientTimeoutRace:
         mock_tv.get_thumbnail.side_effect = intermittent_thumbnail
 
         ids = [f"ART{i:03d}" for i in range(10)]
-        # This request completes (in tests, no actual 30s timeout)
+        # Response returns immediately — no inline individual calls
         resp = await client.post("/api/thumbnails", json={"content_ids": ids})
         data = resp.json()
 
-        # Server returned 5 thumbnails in the response
-        assert len(data["thumbnails"]) == 5
+        assert data["fallback"] is True
+        # Immediate response has all as missing (prefetch in background)
+        assert len(data["missing"]) == 10
 
-        # But crucially: those 5 are ALSO on disk
+        # Give background task time to complete
+        await asyncio.sleep(0.5)
+
+        # Background task cached 5 thumbnails to disk
         cached_count = sum(
             1 for i in range(10)
             if (server.THUMB_DIR / f"ART{i:03d}.jpg").exists()
         )
         assert cached_count == 5, (
-            "Server cached thumbnails to disk during fallback — "
-            "even if the client times out, a retry will find them in cache"
+            "Background prefetch cached thumbnails to disk — "
+            "retry will find them in cache"
         )
 
         # Now simulate the retry — all 10 IDs requested again
@@ -438,8 +464,6 @@ class TestClientTimeoutRace:
         data2 = resp2.json()
         # The 5 cached IDs are served from disk without touching TV
         assert len(data2["thumbnails"]) >= 5
-        # TV should NOT be called for the cached IDs
-        # (it may be called for the 5 missing ones)
 
     def test_frontend_retry_creates_infinite_loop(self):
         """Walk through the exact infinite loop scenario.

--- a/tests/test_reproduce_nitrowolf.py
+++ b/tests/test_reproduce_nitrowolf.py
@@ -79,8 +79,19 @@ def _make_mock_art(
 # Test: Reproduce the full Nitrowolf scenario
 # ---------------------------------------------------------------------------
 
+@pytest.mark.xfail(
+    reason="Reproduces #67 timeout race — will fail once the fix lands",
+    strict=False,
+)
 class TestNitrowolfReproduction:
-    """End-to-end reproduction of Nitrowolf's failure pattern."""
+    """End-to-end reproduction of Nitrowolf's failure pattern.
+
+    These tests assert the *current buggy behavior*: the server responds
+    slower than the client timeout. Once the timeout race is fixed, these
+    tests should start failing (xfail → xpass), signaling that the
+    reproduction no longer applies and the tests can be removed or
+    converted to assert the fixed behavior.
+    """
 
     @pytest.fixture
     def nitrowolf_tv(self, monkeypatch):
@@ -259,6 +270,10 @@ class TestNitrowolfReproduction:
         )
 
 
+@pytest.mark.xfail(
+    reason="Reproduces #67 timeout race — will fail once the fix lands",
+    strict=False,
+)
 class TestRetryLoopReproduction:
     """Reproduce the frontend's retry-abort-retry loop that creates the
     cascading failure pattern in Nitrowolf's logs.
@@ -404,6 +419,10 @@ class TestRetryLoopReproduction:
         print(f"{'='*60}")
 
 
+@pytest.mark.xfail(
+    reason="Reproduces #67 timeout race — will fail once the fix lands",
+    strict=False,
+)
 class TestSettingsDelayReproduction:
     """Reproduce Nitrowolf's report: "Clicking settings is still massively
     delayed and pops up over modal dialogs. It took over a minute before

--- a/tests/test_reproduce_nitrowolf.py
+++ b/tests/test_reproduce_nitrowolf.py
@@ -1,0 +1,491 @@
+"""Reproduce Nitrowolf's exact failure pattern from issue #67 / PR #69.
+
+Nitrowolf (524 artworks, Docker) reports:
+  - Thumbnails fail to load; most show "Tap to retry"
+  - Progress bar never appears
+  - Clicking a failed thumbnail pops it up instantly
+  - Server logs show "POST /api/thumbnails 200 53.48s"
+  - Cascading ConnectionFailure / socket closed errors
+
+This test replicates the exact same behavior locally by simulating the
+TV's failure pattern with scaled-down timing to keep tests fast.
+
+Scaling: real timing → test timing  (50× speedup)
+  TV_RETRY_DELAY:   2s    → 0.04s
+  TV per-op:        ~2s   → 0.04s
+  Client timeout:   30s   → 0.6s (proportional)
+
+All the same dynamics apply — the ratio between server response time
+and client timeout is what matters, not the absolute values.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import server
+from samsungtvws.exceptions import ConnectionFailure
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_art(
+    *,
+    batch_fail: bool = True,
+    individual_fail_after: int = 0,
+    per_call_delay: float = 0.04,
+):
+    """Create a mock art object that simulates Nitrowolf's TV behavior.
+
+    Args:
+        batch_fail: If True, get_thumbnail_list always raises ConnectionFailure.
+        individual_fail_after: Number of successful get_thumbnail calls before
+            all subsequent calls raise ConnectionFailure. 0 = all fail.
+        per_call_delay: Simulated D2D transfer time per operation.
+    """
+    art = MagicMock()
+    call_count = {"individual": 0, "batch": 0}
+
+    def mock_batch(ids):
+        call_count["batch"] += 1
+        time.sleep(per_call_delay)
+        if batch_fail:
+            raise ConnectionFailure({"reason": "socket closed"})
+        return {
+            f"{cid}.jpg": bytearray(b"\xff\xd8\xff\xe0thumb")
+            for cid in ids
+        }
+
+    def mock_individual(cid):
+        call_count["individual"] += 1
+        time.sleep(per_call_delay)
+        if call_count["individual"] <= individual_fail_after:
+            return bytearray(b"\xff\xd8\xff\xe0thumb-" + cid.encode())
+        raise ConnectionFailure({"reason": "socket closed"})
+
+    art.get_thumbnail_list.side_effect = mock_batch
+    art.get_thumbnail.side_effect = mock_individual
+    art._call_count = call_count
+    return art
+
+
+# ---------------------------------------------------------------------------
+# Test: Reproduce the full Nitrowolf scenario
+# ---------------------------------------------------------------------------
+
+class TestNitrowolfReproduction:
+    """End-to-end reproduction of Nitrowolf's failure pattern."""
+
+    @pytest.fixture
+    def nitrowolf_tv(self, monkeypatch):
+        """Configure the server to simulate Nitrowolf's TV behavior."""
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.04)
+        monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())
+
+        art = _make_mock_art(
+            batch_fail=True,
+            individual_fail_after=3,  # First 3 individual calls succeed, rest fail
+            per_call_delay=0.04,
+        )
+
+        monkeypatch.setattr(server, "_ensure_tv_connection", lambda: art)
+        monkeypatch.setattr(server, "_close_tv_connection", lambda: None)
+        return art
+
+    async def test_server_response_exceeds_client_timeout(
+        self, client, nitrowolf_tv, tmp_data_dir
+    ):
+        """The server takes longer to respond than the frontend's 30s timeout.
+
+        This is the smoking gun: the frontend ALWAYS aborts before seeing
+        the response, so the progress bar never shows and the thumbnail
+        data is lost (even though it's cached on disk).
+
+        Timeline (scaled 50×):
+          t=0.00s  Server receives batch of 20 IDs
+          t=0.12s  get_thumbnail_list fails after 3 attempts (0.04s × 3)
+          t=0.20s  Individual fallback starts (20 IDs × 3 attempts × 0.04s)
+          t=0.60s  ← CLIENT TIMEOUT (30s equivalent) — frontend aborts here
+          t=~2.5s  Server finally finishes processing all 20 IDs
+
+        Real timing (unscaled):
+          t=0s     Server receives batch of 20 IDs
+          t=~6s    get_thumbnail_list fails after 3 attempts
+          t=~10s   Individual fallback starts
+          t=30s    ← CLIENT TIMEOUT — frontend aborts
+          t=~53s   Server finally responds (Nitrowolf saw 53.48s)
+        """
+        SCALED_CLIENT_TIMEOUT = 0.6  # 30s / 50
+        ids = [f"MY_F{i:04d}" for i in range(20)]  # Nitrowolf's ID format
+
+        # Time the full server response
+        start = time.monotonic()
+        resp = await client.post("/api/thumbnails", json={"content_ids": ids})
+        server_time = time.monotonic() - start
+
+        data = resp.json()
+
+        # 1. Server response took longer than the client timeout
+        assert server_time > SCALED_CLIENT_TIMEOUT, (
+            f"Server responded in {server_time:.2f}s, but client timeout is "
+            f"{SCALED_CLIENT_TIMEOUT:.2f}s. Expected server to be SLOWER. "
+            f"This means the frontend would abort before receiving this response."
+        )
+
+        # 2. Server DID enter fallback mode
+        assert data["fallback"] is True, (
+            "Server should have fallen back to individual fetches"
+        )
+
+        # 3. Some thumbnails were fetched (first 3 succeed)
+        assert len(data["thumbnails"]) == 3, (
+            f"Expected 3 successful thumbnails, got {len(data['thumbnails'])}"
+        )
+
+        # 4. 17 thumbnails are still missing
+        assert len(data["missing"]) == 17
+
+        # 5. Extrapolate to real timing
+        real_time_estimate = server_time * 50
+        print(f"\n{'='*60}")
+        print(f"REPRODUCTION RESULTS")
+        print(f"{'='*60}")
+        print(f"Server response time (scaled):  {server_time:.2f}s")
+        print(f"Client timeout (scaled):        {SCALED_CLIENT_TIMEOUT:.2f}s")
+        print(f"Server exceeded timeout by:     {server_time - SCALED_CLIENT_TIMEOUT:.2f}s")
+        print(f"")
+        print(f"Estimated real timing:          ~{real_time_estimate:.0f}s")
+        print(f"Nitrowolf's observed timing:    53.48s")
+        print(f"Real client timeout:            30s")
+        print(f"")
+        print(f"Thumbnails fetched:             {len(data['thumbnails'])}/20")
+        print(f"Still missing:                  {len(data['missing'])}/20")
+        print(f"Progress bar would show:        NO (response never received)")
+        print(f"{'='*60}")
+
+    async def test_click_to_retry_reads_from_cache(
+        self, client, nitrowolf_tv, tmp_data_dir
+    ):
+        """After the server processes a batch (even if client aborts), cached
+        thumbnails are available instantly on retry.
+
+        This is why Nitrowolf says: "I decided to click on them and the
+        thumbnail popped up instantly."
+        """
+        ids = [f"MY_F{i:04d}" for i in range(20)]
+
+        # First request: server processes all 20, caches 3 to disk
+        await client.post("/api/thumbnails", json={"content_ids": ids})
+
+        # Verify disk cache
+        cached = [
+            cid for cid in ids
+            if (server.THUMB_DIR / f"{cid}.jpg").exists()
+        ]
+        assert len(cached) == 3, (
+            f"Expected 3 cached thumbnails on disk, found {len(cached)}"
+        )
+
+        # Second request: "click to retry" on one of the cached IDs
+        # This simulates what happens when the user clicks a failed thumbnail
+        retry_id = cached[0]
+        start = time.monotonic()
+        resp = await client.post(
+            "/api/thumbnails",
+            json={"content_ids": [retry_id]},
+        )
+        retry_time = time.monotonic() - start
+
+        data = resp.json()
+        assert retry_id in data["thumbnails"], "Cached thumbnail should load"
+        assert data["fallback"] is False, "No fallback needed — served from cache"
+        assert data["missing"] == []
+
+        # The retry was nearly instant (no TV contact)
+        assert retry_time < 0.1, (
+            f"Retry took {retry_time:.3f}s — should be instant from disk cache"
+        )
+        print(f"\nClick-to-retry time: {retry_time*1000:.1f}ms (instant from cache)")
+
+    async def test_progress_bar_never_shown(
+        self, client, nitrowolf_tv, tmp_data_dir
+    ):
+        """The progress bar is gated on `data.fallback === true` in the
+        frontend response. But the frontend aborts before receiving the
+        response, so `_thumbFallbackSeen` is never set to true.
+
+        Nitrowolf confirmed: "No, I've not seen any loading progress bar."
+        """
+        SCALED_CLIENT_TIMEOUT = 0.6
+        ids = [f"MY_F{i:04d}" for i in range(20)]
+
+        # Simulate the frontend's AbortController behavior:
+        # Fire the request and check if we can get a response within timeout
+        fallback_seen = False
+        timed_out = False
+
+        async def frontend_request():
+            nonlocal fallback_seen
+            resp = await client.post(
+                "/api/thumbnails",
+                json={"content_ids": ids},
+            )
+            data = resp.json()
+            if data.get("fallback"):
+                fallback_seen = True  # This would trigger the progress bar
+            return data
+
+        try:
+            await asyncio.wait_for(
+                frontend_request(),
+                timeout=SCALED_CLIENT_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            timed_out = True
+
+        # The request timed out — exactly what happens in Nitrowolf's browser
+        assert timed_out, "Request should have exceeded the client timeout"
+
+        # And because it timed out, the frontend never saw fallback=true
+        assert not fallback_seen, (
+            "Progress bar should NOT be triggered — "
+            "response was aborted before it arrived"
+        )
+
+
+class TestRetryLoopReproduction:
+    """Reproduce the frontend's retry-abort-retry loop that creates the
+    cascading failure pattern in Nitrowolf's logs.
+    """
+
+    @pytest.fixture
+    def struggling_tv(self, monkeypatch):
+        """TV that fails everything — worst case scenario."""
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.04)
+        monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())
+
+        art = _make_mock_art(
+            batch_fail=True,
+            individual_fail_after=0,  # ALL individual calls also fail
+            per_call_delay=0.04,
+        )
+
+        monkeypatch.setattr(server, "_ensure_tv_connection", lambda: art)
+        monkeypatch.setattr(server, "_close_tv_connection", lambda: None)
+        return art
+
+    async def test_three_attempt_retry_loop(
+        self, client, struggling_tv, tmp_data_dir
+    ):
+        """Simulate the frontend's exact retry logic from loadThumbnailBatch:
+
+            attempt 0: send batch → timeout after 30s → catch, retry in 2s
+            attempt 1: send batch → timeout after 30s → catch, retry in 4s
+            attempt 2: send batch → timeout after 30s → catch, show errors
+
+        With the _tv_lock, these requests serialize: while attempt 0's server
+        handler is still processing, attempt 1 waits for the lock, making
+        everything even slower.
+        """
+        SCALED_CLIENT_TIMEOUT = 0.6
+        BATCH_SIZE = 20
+        ids = [f"MY_F{i:04d}" for i in range(BATCH_SIZE)]
+
+        timeline = []
+        start = time.monotonic()
+
+        def log_event(event: str):
+            elapsed = time.monotonic() - start
+            timeline.append((elapsed, event))
+
+        # Simulate 3 frontend attempts (matching loadThumbnailBatch attempt < 2 + final)
+        for attempt in range(3):
+            log_event(f"attempt {attempt}: sending POST /api/thumbnails")
+            try:
+                await asyncio.wait_for(
+                    client.post("/api/thumbnails", json={"content_ids": ids}),
+                    timeout=SCALED_CLIENT_TIMEOUT,
+                )
+                log_event(f"attempt {attempt}: received response (unexpected!)")
+                break
+            except asyncio.TimeoutError:
+                log_event(f"attempt {attempt}: ABORTED (timeout after {SCALED_CLIENT_TIMEOUT}s)")
+
+            # Frontend retry backoff: 2s × (attempt + 1), scaled
+            if attempt < 2:
+                backoff = 0.04 * (attempt + 1)  # 2s×1, 2s×2 scaled
+                log_event(f"attempt {attempt}: scheduling retry in {backoff:.2f}s")
+                await asyncio.sleep(backoff)
+
+        total_time = time.monotonic() - start
+        log_event("ALL ATTEMPTS EXHAUSTED → showing 'Tap to retry'")
+
+        # Print timeline matching Nitrowolf's log format
+        print(f"\n{'='*60}")
+        print(f"FRONTEND RETRY LOOP REPRODUCTION")
+        print(f"{'='*60}")
+        for elapsed, event in timeline:
+            real_equiv = elapsed * 50
+            print(f"  t={elapsed:6.2f}s (≈{real_equiv:5.0f}s real)  {event}")
+        print(f"{'='*60}")
+        print(f"Total wall time (scaled):   {total_time:.2f}s")
+        print(f"Total wall time (real est):  ~{total_time * 50:.0f}s")
+        print(f"Thumbnails loaded:           0/{BATCH_SIZE}")
+        print(f"User experience:             'Tap to retry' on ALL thumbnails")
+        print(f"{'='*60}")
+
+        # Assertions
+        aborts = [e for _, e in timeline if "ABORTED" in e]
+        assert len(aborts) >= 2, (
+            f"Expected at least 2 timeout aborts, got {len(aborts)}. "
+            f"The frontend aborts every request before the server responds."
+        )
+
+    async def test_concurrent_batches_compound_the_problem(
+        self, client, struggling_tv, tmp_data_dir
+    ):
+        """Nitrowolf has 524 artworks = 26 batches of 20 + 1 batch of 4.
+        The frontend sends these as the IntersectionObserver triggers for
+        visible cards. Multiple batches are in-flight simultaneously, but
+        _tv_lock serializes them — each waiting batch delays all others.
+
+        This test shows that even 3 concurrent batches (the first 3 that
+        fire from IntersectionObserver) create a massive queue.
+        """
+        SCALED_CLIENT_TIMEOUT = 0.6
+        batch_ids = [
+            [f"MY_F{i:04d}" for i in range(0, 20)],
+            [f"MY_F{i:04d}" for i in range(20, 40)],
+            [f"MY_F{i:04d}" for i in range(40, 60)],
+        ]
+
+        results = {"completed": 0, "timed_out": 0}
+        start = time.monotonic()
+
+        async def send_batch(ids, batch_num):
+            try:
+                await asyncio.wait_for(
+                    client.post("/api/thumbnails", json={"content_ids": ids}),
+                    timeout=SCALED_CLIENT_TIMEOUT,
+                )
+                results["completed"] += 1
+            except asyncio.TimeoutError:
+                results["timed_out"] += 1
+
+        # Fire 3 batches concurrently (like IntersectionObserver would)
+        await asyncio.gather(
+            send_batch(batch_ids[0], 0),
+            send_batch(batch_ids[1], 1),
+            send_batch(batch_ids[2], 2),
+        )
+        total_time = time.monotonic() - start
+
+        # All 3 batches should time out
+        assert results["timed_out"] >= 2, (
+            f"Expected at least 2 timeouts (got {results['timed_out']}). "
+            f"The _tv_lock serializes all batches, and each one exceeds "
+            f"the client timeout."
+        )
+
+        print(f"\n{'='*60}")
+        print(f"CONCURRENT BATCH REPRODUCTION")
+        print(f"{'='*60}")
+        print(f"Batches sent concurrently:  3 (of {len(batch_ids[0])} IDs each)")
+        print(f"Completed before timeout:   {results['completed']}")
+        print(f"Timed out:                  {results['timed_out']}")
+        print(f"Total wall time (scaled):   {total_time:.2f}s")
+        print(f"Total wall time (real est):  ~{total_time * 50:.0f}s")
+        print(f"{'='*60}")
+
+
+class TestSettingsDelayReproduction:
+    """Reproduce Nitrowolf's report: "Clicking settings is still massively
+    delayed and pops up over modal dialogs. It took over a minute before
+    the first settings window popped up."
+
+    This happens because the Settings endpoint calls _tv_op (for info/mattes)
+    and the lock is held by the thumbnail fallback loop.
+    """
+
+    @pytest.fixture
+    def busy_tv(self, monkeypatch):
+        """TV occupied with thumbnail fallback."""
+        monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.04)
+        monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())
+
+        art = _make_mock_art(
+            batch_fail=True,
+            individual_fail_after=0,
+            per_call_delay=0.04,
+        )
+        # Mattes endpoint also uses the TV
+        art.get_matte_list.return_value = [
+            {"matte_id": "none", "matte_type": "none"}
+        ]
+
+        monkeypatch.setattr(server, "_ensure_tv_connection", lambda: art)
+        monkeypatch.setattr(server, "_close_tv_connection", lambda: None)
+        return art
+
+    async def test_settings_blocked_by_thumbnail_fallback(
+        self, client, busy_tv, tmp_data_dir
+    ):
+        """While thumbnail individual fallback is processing, a GET /api/mattes
+        request (triggered by opening Settings) is blocked by _tv_lock.
+
+        The lock IS released during retry delays (by design), but the
+        individual fallback loop holds the lock for each of the 20 IDs
+        sequentially — so a mattes request has to wait for at least one
+        full _tv_op cycle to complete before it can acquire the lock.
+        """
+        ids = [f"MY_F{i:04d}" for i in range(20)]
+
+        start = time.monotonic()
+        results = {}
+
+        async def thumbnail_batch():
+            """Simulate ongoing thumbnail loading."""
+            resp = await client.post(
+                "/api/thumbnails",
+                json={"content_ids": ids},
+            )
+            results["thumb_time"] = time.monotonic() - start
+            return resp
+
+        async def settings_request():
+            """User clicks Settings AFTER batch failure, during individual
+            fallback phase. We delay long enough to ensure the batch
+            attempts are done and individual fallback has started.
+            """
+            # Wait for batch to fail (3 attempts × ~0.04s + delays ≈ 0.2s)
+            # and individual fallback to start processing IDs
+            await asyncio.sleep(0.4)
+            req_start = time.monotonic()
+            resp = await client.get("/api/mattes")
+            results["mattes_time"] = time.monotonic() - start
+            results["mattes_wait"] = time.monotonic() - req_start
+            return resp
+
+        await asyncio.gather(thumbnail_batch(), settings_request())
+
+        # The mattes request waited while individual fallback held the lock
+        assert results["mattes_wait"] > 0.03, (
+            f"Settings/mattes request should be delayed by lock contention "
+            f"during individual fallback. Waited {results['mattes_wait']:.3f}s"
+        )
+
+        print(f"\n{'='*60}")
+        print(f"SETTINGS DELAY REPRODUCTION")
+        print(f"{'='*60}")
+        print(f"Thumbnail batch completed at:  t={results['thumb_time']:.2f}s")
+        print(f"Settings/mattes completed at:  t={results['mattes_time']:.2f}s")
+        print(f"Settings wait time (scaled):   {results['mattes_wait']:.2f}s")
+        print(f"Settings wait time (real est):  ~{results['mattes_wait'] * 50:.0f}s")
+        print(f"Nitrowolf reported:            'over a minute'")
+        print(f"{'='*60}")


### PR DESCRIPTION
## Fix: Thumbnail loading timeout race (issue #67)

### Problem
When the Samsung TV's batch thumbnail endpoint (`get_thumbnail_list`) fails, the server fell back to fetching each thumbnail individually — blocking the HTTP response for 53+ seconds while the frontend times out at 30s.

### Root cause
The server's individual-fallback path makes up to `N × 3` sequential `_tv_op` calls (one per artwork, 3 retry attempts each), all while holding the response open. For 20 artworks that's ~53 seconds of blocking.

### Fix (production code changes)

**server.py**
- `get_thumbnails_batch()` now returns immediately with `{"fallback": true, "missing": [...]}` when the batch call fails
- A background task (`_prefetch_thumbnails`) fetches individual thumbnails asynchronously and caches them to disk
- Deduplication set (`_thumb_prefetch_in_progress`) prevents concurrent background fetches for the same content IDs
- WebSocket staleness detection: tracks `_tv_last_used` and proactively reconnects when idle > `TV_CONN_MAX_IDLE` (30s)

**index.html**
- When `fallback: true` is received, the frontend retries up to 8 times at fixed 3s intervals (vs normal 3 attempts with escalating backoff)
- This gives the background prefetch time to populate the cache

### Tests
- **test_reproduce_nitrowolf.py**: Reproduces the exact failure scenario from issue #67 (marked `xfail(strict=False)` since the fix changes the behavior)
- **test_issue67_diagnosis.py**: Tests for timeout behavior, lock contention, WebSocket staleness detection, and large-catalog scenarios
- **test_api_endpoints.py**: Updated fallback tests to verify background prefetch behavior with polling-based assertions

### Review feedback addressed
- Fixed misleading log message ("falling back to individual" → "scheduling background prefetch")
- Fixed misleading code comment about delay durations  
- Replaced fixed `sleep(0.2)` in tests with bounded polling loops
- Fixed test name/docstring mismatch (526 → 524)
- Hanging thread cleanup already uses `threading.Event` with bounded wait

Closes #67