### PR TITLE
fix: throttle background prefetch and add circuit breaker (#67)

### DIFF
--- a/server.py
+++ b/server.py
@@ -478,20 +478,61 @@ async def get_thumbnail(content_id: str):
 # Background thumbnail prefetch — tracks IDs already being fetched so
 # concurrent/retry requests don't spawn duplicate work.
 _thumb_prefetch_in_progress: set[str] = set()
+_thumb_prefetch_running: bool = False
+
+# Circuit breaker for get_thumbnail_list — if the batch call fails, skip
+# it for a cooldown period so retries return the cache instantly.
+_batch_thumb_last_failure: float = 0
+_BATCH_THUMB_COOLDOWN = 60  # seconds
+_PREFETCH_INTER_DELAY = 0.5  # seconds between successful fetches
+_PREFETCH_BACKOFF = 2  # multiplier for consecutive failure delays
+_PREFETCH_MAX_FAILURES = 5  # abort after this many consecutive failures
 
 
 async def _prefetch_thumbnails(content_ids: list[str]) -> None:
-    """Fetch thumbnails individually in the background and cache to disk."""
-    for cid in content_ids:
-        try:
-            data = await _tv_op(lambda art, _cid=cid: art.get_thumbnail(_cid))
-            if data:
-                _save_thumbnail(cid, data)
-                log.debug("Background prefetch cached thumbnail for %s", cid)
-        except Exception:
-            log.debug("Background prefetch failed for %s", cid)
-        finally:
-            _thumb_prefetch_in_progress.discard(cid)
+    """Fetch thumbnails individually in the background and cache to disk.
+
+    Uses single attempts with a short timeout to fail fast, adds a delay
+    between calls to avoid overwhelming the TV, and aborts after several
+    consecutive failures (the TV is likely unreachable).
+    """
+    global _thumb_prefetch_running
+    _thumb_prefetch_running = True
+    consecutive_failures = 0
+    try:
+        for cid in content_ids:
+            if consecutive_failures >= _PREFETCH_MAX_FAILURES:
+                log.warning(
+                    "Background prefetch aborting after %d consecutive failures "
+                    "(%d IDs remaining)",
+                    consecutive_failures,
+                    len(content_ids) - content_ids.index(cid),
+                )
+                # Release remaining IDs from the in-progress set
+                for remaining in content_ids[content_ids.index(cid):]:
+                    _thumb_prefetch_in_progress.discard(remaining)
+                break
+            try:
+                data = await _tv_op(
+                    lambda art, _cid=cid: art.get_thumbnail(_cid),
+                    attempts=1,
+                    timeout=TV_TIMEOUT,
+                )
+                if data:
+                    _save_thumbnail(cid, data)
+                    log.debug("Background prefetch cached thumbnail for %s", cid)
+                consecutive_failures = 0
+                # Brief pause between successful fetches to be gentle on the TV
+                await asyncio.sleep(_PREFETCH_INTER_DELAY)
+            except Exception:
+                consecutive_failures += 1
+                log.debug("Background prefetch failed for %s (%d consecutive)", cid, consecutive_failures)
+                # Back off longer after failures
+                await asyncio.sleep(_PREFETCH_BACKOFF * consecutive_failures)
+            finally:
+                _thumb_prefetch_in_progress.discard(cid)
+    finally:
+        _thumb_prefetch_running = False
 
 
 @app.post("/api/thumbnails")
@@ -512,17 +553,31 @@ async def get_thumbnails_batch(body: dict):
 
     fallback = False
     if missing:
-        try:
-            result = await _tv_op(lambda art: art.get_thumbnail_list(missing))
-            for name, data in result.items():
-                for cid in missing:
-                    if name.startswith(cid):
-                        _save_thumbnail(cid, data)
-                        encoded[cid] = base64.b64encode(bytes(data)).decode()
-                        break
-        except Exception as e:
-            log.warning("Batch thumbnail fetch failed, scheduling background prefetch: %s", e)
+        global _batch_thumb_last_failure
+        # Circuit breaker: if get_thumbnail_list failed recently, skip it
+        # entirely and serve what we have from cache.  This prevents the
+        # endpoint from blocking 8-60s on a call that will definitely fail,
+        # which is what was causing the 69-131s response times.
+        since_last_failure = time.monotonic() - _batch_thumb_last_failure
+        skip_batch = since_last_failure < _BATCH_THUMB_COOLDOWN
+
+        if skip_batch:
             fallback = True
+        else:
+            try:
+                result = await _tv_op(lambda art: art.get_thumbnail_list(missing))
+                for name, data in result.items():
+                    for cid in missing:
+                        if name.startswith(cid):
+                            _save_thumbnail(cid, data)
+                            encoded[cid] = base64.b64encode(bytes(data)).decode()
+                            break
+            except Exception as e:
+                _batch_thumb_last_failure = time.monotonic()
+                log.warning("Batch thumbnail fetch failed, scheduling background prefetch: %s", e)
+                fallback = True
+
+        if fallback:
             # Instead of blocking the response with 20+ individual TV calls,
             # return immediately and prefetch the missing thumbnails in the
             # background.  The client will retry and find them cached on disk.
@@ -530,7 +585,7 @@ async def get_thumbnails_batch(body: dict):
                 cid for cid in missing
                 if cid not in encoded and cid not in _thumb_prefetch_in_progress
             ]
-            if to_prefetch:
+            if to_prefetch and not _thumb_prefetch_running:
                 _thumb_prefetch_in_progress.update(to_prefetch)
                 asyncio.create_task(_prefetch_thumbnails(to_prefetch))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,8 @@ def tmp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_tv_last_used", 0)
     monkeypatch.setattr(server, "_nws_station_cache", {})
     monkeypatch.setattr(server, "_thumb_prefetch_in_progress", set())
+    monkeypatch.setattr(server, "_thumb_prefetch_running", False)
+    monkeypatch.setattr(server, "_batch_thumb_last_failure", 0)
     monkeypatch.setattr(server, "_tv_lock", asyncio.Lock())
 
     return tmp_path

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -447,11 +447,13 @@ class TestThumbnailBatchFallback:
         assert "ART001" in data["thumbnails"]
         assert data["missing"] == []
 
-    async def test_batch_failure_falls_back_to_background_prefetch(self, client, mock_tv, tmp_data_dir):
+    async def test_batch_failure_falls_back_to_background_prefetch(self, client, mock_tv, tmp_data_dir, monkeypatch):
         """When get_thumbnail_list fails, response returns immediately with
         fallback=True and missing IDs; a background task prefetches them."""
         mock_tv.get_thumbnail_list.side_effect = Exception("socket closed")
         mock_tv.get_thumbnail.return_value = b"\xff\xd8\xff\xe0thumb-individual"
+        # Speed up inter-fetch delays in tests
+        monkeypatch.setattr(server, "_BATCH_THUMB_COOLDOWN", 0.1)
 
         resp = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
         assert resp.status_code == 200
@@ -463,7 +465,7 @@ class TestThumbnailBatchFallback:
 
         # Poll for background prefetch to complete (avoids fixed-sleep flakiness)
         import asyncio
-        for _ in range(20):
+        for _ in range(40):
             await asyncio.sleep(0.1)
             resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
             data2 = resp2.json()
@@ -473,10 +475,12 @@ class TestThumbnailBatchFallback:
         assert "ART002" in data2["thumbnails"]
         assert data2["missing"] == []
 
-    async def test_partial_fallback_results(self, client, mock_tv, tmp_data_dir):
+    async def test_partial_fallback_results(self, client, mock_tv, tmp_data_dir, monkeypatch):
         """When batch fails, missing IDs are prefetched in background.
         IDs that the TV can't fetch remain missing even after retry."""
         mock_tv.get_thumbnail_list.side_effect = Exception("socket closed")
+        # Speed up inter-fetch delays in tests
+        monkeypatch.setattr(server, "_BATCH_THUMB_COOLDOWN", 0.1)
 
         def _get_thumb(cid):
             if cid == "ART001":
@@ -493,7 +497,7 @@ class TestThumbnailBatchFallback:
 
         # Poll for background prefetch to complete (avoids fixed-sleep flakiness)
         import asyncio
-        for _ in range(20):
+        for _ in range(40):
             await asyncio.sleep(0.1)
             resp2 = await client.post("/api/thumbnails", json={"content_ids": ["ART001", "ART002"]})
             data2 = resp2.json()

--- a/tests/test_issue67_diagnosis.py
+++ b/tests/test_issue67_diagnosis.py
@@ -80,6 +80,9 @@ class TestIndividualFallbackBehavior:
         """Response returns fast with all IDs as missing; background task
         fetches them individually and caches to disk."""
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
+        monkeypatch.setattr(server, "_BATCH_THUMB_COOLDOWN", 0.1)
+        monkeypatch.setattr(server, "_PREFETCH_INTER_DELAY", 0.01)
+        monkeypatch.setattr(server, "_PREFETCH_BACKOFF", 0.01)
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
         mock_tv.get_thumbnail.return_value = bytearray(b"\xff\xd8\xff\xe0thumb")
 
@@ -97,22 +100,28 @@ class TestIndividualFallbackBehavior:
         # No thumbnails inline (they're being prefetched)
         assert len(data["thumbnails"]) == 0
 
-        # Give background task time to run
-        await asyncio.sleep(0.5)
+        # Poll for background task to finish (has 0.5s inter-fetch delays)
+        for _ in range(150):
+            await asyncio.sleep(0.1)
+            if not server._thumb_prefetch_running:
+                break
 
         # Now the background task should have cached them
         resp2 = await client.post("/api/thumbnails", json={"content_ids": ids})
         data2 = resp2.json()
         assert len(data2["thumbnails"]) == 20
         assert data2["missing"] == []
-        # Background task made 20 individual get_thumbnail calls
+        # Background task made 20 individual get_thumbnail calls (1 attempt each)
         assert mock_tv.get_thumbnail.call_count == 20
 
     async def test_fallback_cascading_failures(self, client, mock_tv, tmp_data_dir, monkeypatch):
         """When the TV is unstable, background prefetch caches what it can
-        and drops the rest.
+        and aborts after consecutive failures.
         """
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.01)
+        monkeypatch.setattr(server, "_BATCH_THUMB_COOLDOWN", 0.1)
+        monkeypatch.setattr(server, "_PREFETCH_INTER_DELAY", 0.01)
+        monkeypatch.setattr(server, "_PREFETCH_BACKOFF", 0.01)
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
         call_count = 0
         def flaky_get_thumbnail(cid):
@@ -131,10 +140,14 @@ class TestIndividualFallbackBehavior:
         # Immediate response has all 10 as missing
         assert len(data["missing"]) == 10
 
-        # Give background task time to finish
-        await asyncio.sleep(0.5)
+        # Poll for background task to finish
+        for _ in range(200):
+            await asyncio.sleep(0.1)
+            if not server._thumb_prefetch_running:
+                break
 
-        # Retry — only 3 were cached successfully
+        # Retry — only 3 were cached successfully; prefetch aborted after
+        # 5 consecutive failures (calls 4-8), leaving IDs 8-9 unattempted.
         resp2 = await client.post("/api/thumbnails", json={"content_ids": ids})
         data2 = resp2.json()
         assert len(data2["thumbnails"]) == 3
@@ -282,10 +295,14 @@ class TestLargeCatalogScenario:
         If ALL fail and trigger individual fallback, that's up to
         524 individual _tv_op calls, each with 3 attempts = 1,572 connection attempts.
 
-        With the background prefetch fix, the response returns immediately
-        and the individual calls happen asynchronously.
+        With the throttled background prefetch fix, the response returns
+        immediately, the prefetch uses single attempts, and it aborts
+        after 5 consecutive failures to avoid hammering the TV.
         """
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.001)
+        monkeypatch.setattr(server, "_BATCH_THUMB_COOLDOWN", 0.1)
+        monkeypatch.setattr(server, "_PREFETCH_INTER_DELAY", 0.01)
+        monkeypatch.setattr(server, "_PREFETCH_BACKOFF", 0.01)
 
         batch_call_count = 0
 
@@ -309,12 +326,16 @@ class TestLargeCatalogScenario:
         # Response returns fast — no inline individual calls
         assert elapsed < 2.0, f"Response took {elapsed:.2f}s, should be bounded"
 
-        # Give background task time to attempt individual calls
-        await asyncio.sleep(0.5)
+        # Give background task time to attempt individual calls and abort
+        for _ in range(50):
+            await asyncio.sleep(0.2)
+            if not server._thumb_prefetch_running:
+                break
 
-        # Background task attempted individual calls (20 IDs × 3 attempts each)
-        assert mock_tv.get_thumbnail.call_count >= 20, (
-            f"Expected at least 20 background individual calls, got {mock_tv.get_thumbnail.call_count}"
+        # Background task aborted after 5 consecutive failures (not all 20)
+        assert mock_tv.get_thumbnail.call_count == 5, (
+            f"Expected exactly 5 background individual calls before abort, "
+            f"got {mock_tv.get_thumbnail.call_count}"
         )
 
     async def test_cached_thumbnails_skip_tv_entirely(self, client, mock_tv, tmp_data_dir):
@@ -421,6 +442,9 @@ class TestClientTimeoutRace:
         are available on retry. This eliminates the timeout race entirely.
         """
         monkeypatch.setattr(server, "TV_RETRY_DELAY", 0.001)
+        monkeypatch.setattr(server, "_BATCH_THUMB_COOLDOWN", 0.1)
+        monkeypatch.setattr(server, "_PREFETCH_INTER_DELAY", 0.01)
+        monkeypatch.setattr(server, "_PREFETCH_BACKOFF", 0.01)
         mock_tv.get_thumbnail_list.side_effect = ConnectionFailure({"reason": "socket closed"})
 
         call_idx = 0
@@ -443,8 +467,11 @@ class TestClientTimeoutRace:
         # Immediate response has all as missing (prefetch in background)
         assert len(data["missing"]) == 10
 
-        # Give background task time to complete
-        await asyncio.sleep(0.5)
+        # Poll for background task to finish
+        for _ in range(100):
+            await asyncio.sleep(0.1)
+            if not server._thumb_prefetch_running:
+                break
 
         # Background task cached 5 thumbnails to disk
         cached_count = sum(


### PR DESCRIPTION
## Fix: Thumbnail prefetch hammering TV into ConnectionFailure spiral

### What went wrong with v1.2.0

The background prefetch fix (PR #70) made things **worse** for users with consistently failing `get_thumbnail_list`. Nitrowolf's v1.2.0 logs showed:

- `POST /api/thumbnails 200 69.59s` — response took **69 seconds**
- `POST /api/thumbnails 200 131.01s` — response took **131 seconds**
- Dozens of `TV op attempt 1/3 failed (ConnectionFailure)` per second
- The TV was completely overwhelmed

**Root cause**: 27 batches of 20 IDs each spawned background prefetch tasks. Each task tried 20 individual `_tv_op` calls with 3 attempts × 18s timeout each, all serialized through one lock. That's potentially 525 × 3 × 18s = **8+ hours** of lock contention. Meanwhile, the frontend's 8 retries also queued up behind the same lock, and each retry re-attempted the failing `get_thumbnail_list` call (another 8s per try).

### Three fixes

1. **Circuit breaker** on `get_thumbnail_list`: if it failed in the last 60s, skip it entirely and return the cache state in 0ms (vs 8-60s blocking)

2. **Throttled prefetch**: single attempt per thumbnail (`attempts=1`), 0.5s pause between successes, exponential backoff on failure (2s, 4s, 6s…), abort after 5 consecutive failures

3. **Single prefetch task**: don't spawn additional background tasks while one is already running (prevents 27 prefetch tasks piling up)

### Expected behavior for Nitrowolf

- First batch request: `get_thumbnail_list` fails → returns immediately with `fallback: true` → spawns ONE prefetch task
- All subsequent batch requests (other 26 batches + retries): circuit breaker skips the TV call → returns cache state in <1ms
- Background prefetch fetches thumbnails one at a time with pauses, gives up after 5 consecutive failures
- No more ConnectionFailure spam, no more 69-131s response times

Closes #67