### PR TITLE
fix: whitelist artwork-meta keys and validate image format on upload (#23, #24)

### DIFF
--- a/server.py
+++ b/server.py
@@ -20,7 +20,7 @@ import httpx
 from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse, Response
 from starlette.staticfiles import StaticFiles
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from samsungtvws import SamsungTVWS
 from samsungtvws.exceptions import ResponseError
 
@@ -268,6 +268,7 @@ def _validate_content_ids(cids: list) -> list[str]:
 
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 MAX_NAME_LENGTH = 200
+_ALLOWED_META_KEYS = {"title"}
 
 
 def _validate_name(name: str, field: str = "name") -> str:
@@ -279,6 +280,29 @@ def _validate_name(name: str, field: str = "name") -> str:
     if _CONTROL_CHAR_RE.search(name):
         raise HTTPException(400, f"{field} contains invalid characters")
     return name
+
+
+Image.MAX_IMAGE_PIXELS = 50_000_000  # ~50MP; guards against decompression bombs
+
+_ALLOWED_IMAGE_FORMATS = {"JPEG", "PNG", "WEBP"}
+
+
+class _UnsupportedImageError(ValueError):
+    pass
+
+
+def _open_validated_image(data: bytes) -> Image.Image:
+    """Open and validate an uploaded image, rejecting bomb-prone/unsupported formats."""
+    try:
+        img = Image.open(io.BytesIO(data))
+        img.load()
+    except Image.DecompressionBombError:
+        raise _UnsupportedImageError("Image dimensions too large")
+    except UnidentifiedImageError:
+        raise _UnsupportedImageError("Unrecognized image format")
+    if img.format not in _ALLOWED_IMAGE_FORMATS:
+        raise _UnsupportedImageError(f"Unsupported image format: {img.format}")
+    return img
 
 
 def _cached_content_ids() -> set[str]:
@@ -773,7 +797,10 @@ async def upload_art(
     if ext == "jpeg":
         ext = "jpg"
 
-    img = Image.open(io.BytesIO(data))
+    try:
+        img = _open_validated_image(data)
+    except _UnsupportedImageError as e:
+        raise HTTPException(400, str(e))
     w, h = img.size
 
     if ext not in ("jpg", "png"):
@@ -1111,6 +1138,8 @@ async def update_artwork_meta(content_id: str, body: dict):
         if content_id not in data["artwork"]:
             data["artwork"][content_id] = {}
         for key, value in body.items():
+            if key not in _ALLOWED_META_KEYS:
+                continue
             if key == "title":
                 if isinstance(value, str):
                     value = value.strip()
@@ -1961,7 +1990,7 @@ async def run_drive_sync(sync_id: str):
                 continue
             try:
                 image_data = await _drive_download_file(file_id, api_key)
-                img = Image.open(io.BytesIO(image_data))
+                img = _open_validated_image(image_data)
                 w, h = img.size
                 ext = Path(df["name"]).suffix.lstrip(".").lower()
                 if ext == "jpeg":

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -205,18 +205,26 @@ class TestArtworkMeta:
         assert resp.json()["artwork"]["ID1"]["title"] == "Starry Night"
 
     async def test_put_creates_entry(self, client):
-        resp = await client.put("/api/artwork-meta/NEW1", json={"title": "Test Art", "width": 1920})
+        resp = await client.put("/api/artwork-meta/NEW1", json={"title": "Test Art"})
         assert resp.status_code == 200
         assert resp.json()["meta"]["title"] == "Test Art"
-        assert resp.json()["meta"]["width"] == 1920
 
     async def test_put_empty_title_skipped(self, client, tmp_data_dir):
         meta = {"artwork": {"ID1": {"title": "Keep This"}}}
         (tmp_data_dir / "artwork_meta.json").write_text(json.dumps(meta))
-        await client.put("/api/artwork-meta/ID1", json={"title": "  ", "width": 100})
+        await client.put("/api/artwork-meta/ID1", json={"title": "  "})
         loaded = server._load_artwork_meta()
         assert loaded["artwork"]["ID1"]["title"] == "Keep This"
-        assert loaded["artwork"]["ID1"]["width"] == 100
+
+    async def test_put_unknown_key_ignored(self, client):
+        resp = await client.put(
+            "/api/artwork-meta/NEW2", json={"title": "Foo", "garbage": "x" * 1000}
+        )
+        assert resp.status_code == 200
+        meta = resp.json()["meta"]
+        assert meta["title"] == "Foo"
+        assert "garbage" not in meta
+        assert "garbage" not in server._load_artwork_meta()["artwork"]["NEW2"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_validation.py
+++ b/tests/test_image_validation.py
@@ -1,0 +1,38 @@
+"""Unit tests for _open_validated_image (issue #24): format allowlist and
+decompression-bomb guarding. Covers both the /api/upload and Drive-import
+call sites, which share this helper.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+import server
+
+
+def _image_bytes(fmt: str = "PNG", size: tuple[int, int] = (32, 32)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, (12, 34, 56)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestOpenValidatedImage:
+    @pytest.mark.parametrize("fmt", ["PNG", "JPEG", "WEBP"])
+    def test_accepts_allowed_formats(self, fmt):
+        img = server._open_validated_image(_image_bytes(fmt=fmt))
+        assert img.format == fmt
+
+    def test_rejects_bmp(self):
+        with pytest.raises(server._UnsupportedImageError):
+            server._open_validated_image(_image_bytes(fmt="BMP"))
+
+    def test_rejects_garbage_bytes(self):
+        with pytest.raises(server._UnsupportedImageError):
+            server._open_validated_image(b"not an image")
+
+    def test_rejects_oversized_dimensions(self, monkeypatch):
+        monkeypatch.setattr(server.Image, "MAX_IMAGE_PIXELS", 100)
+        with pytest.raises(server._UnsupportedImageError):
+            server._open_validated_image(_image_bytes())

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -50,3 +50,27 @@ class TestUpload:
 
         assert resp.status_code == 413
         assert not mock_tv.upload.called
+
+    async def test_upload_rejects_unsupported_format(self, client, mock_tv):
+        """BMP is bomb-prone and not in the allowlist — rejected with 400."""
+        resp = await client.post(
+            "/api/upload",
+            files={"file": ("art.bmp", _image_bytes(fmt="BMP"), "image/bmp")},
+            data={"matte": "none"},
+        )
+
+        assert resp.status_code == 400
+        assert not mock_tv.upload.called
+
+    async def test_upload_rejects_decompression_bomb(self, client, mock_tv, monkeypatch):
+        """Images exceeding MAX_IMAGE_PIXELS are rejected with 400."""
+        monkeypatch.setattr("server.Image.MAX_IMAGE_PIXELS", 100)
+
+        resp = await client.post(
+            "/api/upload",
+            files={"file": ("art.png", _image_bytes(), "image/png")},
+            data={"matte": "none"},
+        )
+
+        assert resp.status_code == 400
+        assert not mock_tv.upload.called


### PR DESCRIPTION
PUT /api/artwork-meta/{id} previously wrote any key from the request body
into artwork_meta.json; restrict it to the only field the UI actually
sends (title).

Image.open() on uploaded/Drive-imported bytes had no format allowlist or
MAX_IMAGE_PIXELS cap, allowing decompression-bomb-style uploads (e.g. a
crafted BMP). Add a shared _open_validated_image() helper used by both
upload_art and run_drive_sync that rejects unsupported formats and
oversized images.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QjJFoWX7MgP6QngpzBozSX