### PR TITLE
Smart Crop: content-aware 16:9 seeding with Google Vision Enhanced Mode

### DIFF
--- a/assets/js/smartcrop.js
+++ b/assets/js/smartcrop.js
@@ -1,0 +1,594 @@
+/**
+ * smartcrop.js
+ * A javascript library implementing content aware image cropping
+ *
+ * Copyright (C) 2018 Jonas Wagner
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+(function() {
+  'use strict';
+
+  var smartcrop = {};
+  // Promise implementation to use
+  function NoPromises() {
+    throw new Error('No native promises and smartcrop.Promise not set.');
+  }
+
+  smartcrop.Promise = typeof Promise !== 'undefined' ? Promise : NoPromises;
+
+  smartcrop.DEFAULTS = {
+    width: 0,
+    height: 0,
+    aspect: 0,
+    cropWidth: 0,
+    cropHeight: 0,
+    detailWeight: 0.2,
+    skinColor: [0.78, 0.57, 0.44],
+    skinBias: 0.01,
+    skinBrightnessMin: 0.2,
+    skinBrightnessMax: 1.0,
+    skinThreshold: 0.8,
+    skinWeight: 1.8,
+    saturationBrightnessMin: 0.05,
+    saturationBrightnessMax: 0.9,
+    saturationThreshold: 0.4,
+    saturationBias: 0.2,
+    saturationWeight: 0.1,
+    // Step * minscale rounded down to the next power of two should be good
+    scoreDownSample: 8,
+    step: 8,
+    scaleStep: 0.1,
+    minScale: 1.0,
+    maxScale: 1.0,
+    edgeRadius: 0.4,
+    edgeWeight: -20.0,
+    outsideImportance: -0.5,
+    boostWeight: 100.0,
+    ruleOfThirds: true,
+    prescale: true,
+    imageOperations: null,
+    canvasFactory: defaultCanvasFactory,
+    // Factory: defaultFactories,
+    debug: false
+  };
+
+  smartcrop.crop = function(inputImage, options_, callback) {
+    var options = extend({}, smartcrop.DEFAULTS, options_);
+
+    if (options.aspect) {
+      options.width = options.aspect;
+      options.height = 1;
+    }
+
+    if (options.imageOperations === null) {
+      options.imageOperations = canvasImageOperations(options.canvasFactory);
+    }
+
+    var iop = options.imageOperations;
+
+    var scale = 1;
+    var prescale = 1;
+
+    // open the image
+    return iop
+      .open(inputImage, options.input)
+      .then(function(image) {
+        // calculate desired crop dimensions based on the image size
+        if (options.width && options.height) {
+          scale = min(
+            image.width / options.width,
+            image.height / options.height
+          );
+          options.cropWidth = ~~(options.width * scale);
+          options.cropHeight = ~~(options.height * scale);
+          // Img = 100x100, width = 95x95, scale = 100/95, 1/scale > min
+          // don't set minscale smaller than 1/scale
+          // -> don't pick crops that need upscaling
+          options.minScale = min(
+            options.maxScale,
+            max(1 / scale, options.minScale)
+          );
+
+          // prescale if possible
+          if (options.prescale !== false) {
+            prescale = min(max(256 / image.width, 256 / image.height), 1);
+            if (prescale < 1) {
+              image = iop.resample(
+                image,
+                image.width * prescale,
+                image.height * prescale
+              );
+              options.cropWidth = ~~(options.cropWidth * prescale);
+              options.cropHeight = ~~(options.cropHeight * prescale);
+              if (options.boost) {
+                options.boost = options.boost.map(function(boost) {
+                  return {
+                    x: ~~(boost.x * prescale),
+                    y: ~~(boost.y * prescale),
+                    width: ~~(boost.width * prescale),
+                    height: ~~(boost.height * prescale),
+                    weight: boost.weight
+                  };
+                });
+              }
+            } else {
+              prescale = 1;
+            }
+          }
+        }
+        return image;
+      })
+      .then(function(image) {
+        return iop.getData(image).then(function(data) {
+          var result = analyse(options, data);
+
+          var crops = result.crops || [result.topCrop];
+          for (var i = 0, iLen = crops.length; i < iLen; i++) {
+            var crop = crops[i];
+            crop.x = ~~(crop.x / prescale);
+            crop.y = ~~(crop.y / prescale);
+            crop.width = ~~(crop.width / prescale);
+            crop.height = ~~(crop.height / prescale);
+          }
+          if (callback) callback(result);
+          return result;
+        });
+      });
+  };
+
+  // Check if all the dependencies are there
+  // todo:
+  smartcrop.isAvailable = function(options) {
+    if (!smartcrop.Promise) return false;
+
+    var canvasFactory = options ? options.canvasFactory : defaultCanvasFactory;
+
+    if (canvasFactory === defaultCanvasFactory) {
+      var c = document.createElement('canvas');
+      if (!c.getContext('2d')) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  function edgeDetect(i, o) {
+    var id = i.data;
+    var od = o.data;
+    var w = i.width;
+    var h = i.height;
+
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        var p = (y * w + x) * 4;
+        var lightness;
+
+        if (x === 0 || x >= w - 1 || y === 0 || y >= h - 1) {
+          lightness = sample(id, p);
+        } else {
+          lightness =
+            sample(id, p) * 4 -
+            sample(id, p - w * 4) -
+            sample(id, p - 4) -
+            sample(id, p + 4) -
+            sample(id, p + w * 4);
+        }
+
+        od[p + 1] = lightness;
+      }
+    }
+  }
+
+  function skinDetect(options, i, o) {
+    var id = i.data;
+    var od = o.data;
+    var w = i.width;
+    var h = i.height;
+
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        var p = (y * w + x) * 4;
+        var lightness = cie(id[p], id[p + 1], id[p + 2]) / 255;
+        var skin = skinColor(options, id[p], id[p + 1], id[p + 2]);
+        var isSkinColor = skin > options.skinThreshold;
+        var isSkinBrightness =
+          lightness >= options.skinBrightnessMin &&
+          lightness <= options.skinBrightnessMax;
+        if (isSkinColor && isSkinBrightness) {
+          od[p] =
+            (skin - options.skinThreshold) *
+            (255 / (1 - options.skinThreshold));
+        } else {
+          od[p] = 0;
+        }
+      }
+    }
+  }
+
+  function saturationDetect(options, i, o) {
+    var id = i.data;
+    var od = o.data;
+    var w = i.width;
+    var h = i.height;
+    for (var y = 0; y < h; y++) {
+      for (var x = 0; x < w; x++) {
+        var p = (y * w + x) * 4;
+
+        var lightness = cie(id[p], id[p + 1], id[p + 2]) / 255;
+        var sat = saturation(id[p], id[p + 1], id[p + 2]);
+
+        var acceptableSaturation = sat > options.saturationThreshold;
+        var acceptableLightness =
+          lightness >= options.saturationBrightnessMin &&
+          lightness <= options.saturationBrightnessMax;
+        if (acceptableLightness && acceptableSaturation) {
+          od[p + 2] =
+            (sat - options.saturationThreshold) *
+            (255 / (1 - options.saturationThreshold));
+        } else {
+          od[p + 2] = 0;
+        }
+      }
+    }
+  }
+
+  function applyBoosts(options, output) {
+    if (!options.boost) return;
+    var od = output.data;
+    for (var i = 0; i < output.width; i += 4) {
+      od[i + 3] = 0;
+    }
+    for (i = 0; i < options.boost.length; i++) {
+      applyBoost(options.boost[i], options, output);
+    }
+  }
+
+  function applyBoost(boost, options, output) {
+    var od = output.data;
+    var w = output.width;
+    var x0 = ~~boost.x;
+    var x1 = ~~(boost.x + boost.width);
+    var y0 = ~~boost.y;
+    var y1 = ~~(boost.y + boost.height);
+    var weight = boost.weight * 255;
+    for (var y = y0; y < y1; y++) {
+      for (var x = x0; x < x1; x++) {
+        var i = (y * w + x) * 4;
+        od[i + 3] += weight;
+      }
+    }
+  }
+
+  function generateCrops(options, width, height) {
+    var results = [];
+    var minDimension = min(width, height);
+    var cropWidth = options.cropWidth || minDimension;
+    var cropHeight = options.cropHeight || minDimension;
+    for (
+      var scale = options.maxScale;
+      scale >= options.minScale;
+      scale -= options.scaleStep
+    ) {
+      for (var y = 0; y + cropHeight * scale <= height; y += options.step) {
+        for (var x = 0; x + cropWidth * scale <= width; x += options.step) {
+          results.push({
+            x: x,
+            y: y,
+            width: cropWidth * scale,
+            height: cropHeight * scale
+          });
+        }
+      }
+    }
+    return results;
+  }
+
+  function score(options, output, crop) {
+    var result = {
+      detail: 0,
+      saturation: 0,
+      skin: 0,
+      boost: 0,
+      total: 0
+    };
+
+    var od = output.data;
+    var downSample = options.scoreDownSample;
+    var invDownSample = 1 / downSample;
+    var outputHeightDownSample = output.height * downSample;
+    var outputWidthDownSample = output.width * downSample;
+    var outputWidth = output.width;
+
+    for (var y = 0; y < outputHeightDownSample; y += downSample) {
+      for (var x = 0; x < outputWidthDownSample; x += downSample) {
+        var p =
+          (~~(y * invDownSample) * outputWidth + ~~(x * invDownSample)) * 4;
+        var i = importance(options, crop, x, y);
+        var detail = od[p + 1] / 255;
+
+        result.skin += (od[p] / 255) * (detail + options.skinBias) * i;
+        result.detail += detail * i;
+        result.saturation +=
+          (od[p + 2] / 255) * (detail + options.saturationBias) * i;
+        result.boost += (od[p + 3] / 255) * i;
+      }
+    }
+
+    result.total =
+      (result.detail * options.detailWeight +
+        result.skin * options.skinWeight +
+        result.saturation * options.saturationWeight +
+        result.boost * options.boostWeight) /
+      (crop.width * crop.height);
+    return result;
+  }
+
+  function importance(options, crop, x, y) {
+    if (
+      crop.x > x ||
+      x >= crop.x + crop.width ||
+      crop.y > y ||
+      y >= crop.y + crop.height
+    ) {
+      return options.outsideImportance;
+    }
+    x = (x - crop.x) / crop.width;
+    y = (y - crop.y) / crop.height;
+    var px = abs(0.5 - x) * 2;
+    var py = abs(0.5 - y) * 2;
+    // Distance from edge
+    var dx = Math.max(px - 1.0 + options.edgeRadius, 0);
+    var dy = Math.max(py - 1.0 + options.edgeRadius, 0);
+    var d = (dx * dx + dy * dy) * options.edgeWeight;
+    var s = 1.41 - sqrt(px * px + py * py);
+    if (options.ruleOfThirds) {
+      s += Math.max(0, s + d + 0.5) * 1.2 * (thirds(px) + thirds(py));
+    }
+    return s + d;
+  }
+  smartcrop.importance = importance;
+
+  function skinColor(options, r, g, b) {
+    var mag = sqrt(r * r + g * g + b * b);
+    var rd = r / mag - options.skinColor[0];
+    var gd = g / mag - options.skinColor[1];
+    var bd = b / mag - options.skinColor[2];
+    var d = sqrt(rd * rd + gd * gd + bd * bd);
+    return 1 - d;
+  }
+
+  function analyse(options, input) {
+    var result = {};
+    var output = new ImgData(input.width, input.height);
+
+    edgeDetect(input, output);
+    skinDetect(options, input, output);
+    saturationDetect(options, input, output);
+    applyBoosts(options, output);
+
+    var scoreOutput = downSample(output, options.scoreDownSample);
+
+    var topScore = -Infinity;
+    var topCrop = null;
+    var crops = generateCrops(options, input.width, input.height);
+
+    for (var i = 0, iLen = crops.length; i < iLen; i++) {
+      var crop = crops[i];
+      crop.score = score(options, scoreOutput, crop);
+      if (crop.score.total > topScore) {
+        topCrop = crop;
+        topScore = crop.score.total;
+      }
+    }
+
+    result.topCrop = topCrop;
+
+    if (options.debug && topCrop) {
+      result.crops = crops;
+      result.debugOutput = output;
+      result.debugOptions = options;
+      // Create a copy which will not be adjusted by the post scaling of smartcrop.crop
+      result.debugTopCrop = extend({}, result.topCrop);
+    }
+    return result;
+  }
+
+  function ImgData(width, height, data) {
+    this.width = width;
+    this.height = height;
+    if (data) {
+      this.data = new Uint8ClampedArray(data);
+    } else {
+      this.data = new Uint8ClampedArray(width * height * 4);
+    }
+  }
+  smartcrop.ImgData = ImgData;
+
+  function downSample(input, factor) {
+    var idata = input.data;
+    var iwidth = input.width;
+    var width = Math.floor(input.width / factor);
+    var height = Math.floor(input.height / factor);
+    var output = new ImgData(width, height);
+    var data = output.data;
+    var ifactor2 = 1 / (factor * factor);
+    for (var y = 0; y < height; y++) {
+      for (var x = 0; x < width; x++) {
+        var i = (y * width + x) * 4;
+
+        var r = 0;
+        var g = 0;
+        var b = 0;
+        var a = 0;
+
+        var mr = 0;
+        var mg = 0;
+
+        for (var v = 0; v < factor; v++) {
+          for (var u = 0; u < factor; u++) {
+            var j = ((y * factor + v) * iwidth + (x * factor + u)) * 4;
+            r += idata[j];
+            g += idata[j + 1];
+            b += idata[j + 2];
+            a += idata[j + 3];
+            mr = Math.max(mr, idata[j]);
+            mg = Math.max(mg, idata[j + 1]);
+            // unused
+            // mb = Math.max(mb, idata[j + 2]);
+          }
+        }
+        // this is some funky magic to preserve detail a bit more for
+        // skin (r) and detail (g). Saturation (b) does not get this boost.
+        data[i] = r * ifactor2 * 0.5 + mr * 0.5;
+        data[i + 1] = g * ifactor2 * 0.7 + mg * 0.3;
+        data[i + 2] = b * ifactor2;
+        data[i + 3] = a * ifactor2;
+      }
+    }
+    return output;
+  }
+  smartcrop._downSample = downSample;
+
+  function defaultCanvasFactory(w, h) {
+    var c = document.createElement('canvas');
+    c.width = w;
+    c.height = h;
+    return c;
+  }
+
+  function canvasImageOperations(canvasFactory) {
+    return {
+      // Takes imageInput as argument
+      // returns an object which has at least
+      // {width: n, height: n}
+      open: function(image) {
+        // Work around images scaled in css by drawing them onto a canvas
+        var w = image.naturalWidth || image.width;
+        var h = image.naturalHeight || image.height;
+        var c = canvasFactory(w, h);
+        var ctx = c.getContext('2d');
+        if (
+          image.naturalWidth &&
+          (image.naturalWidth != image.width ||
+            image.naturalHeight != image.height)
+        ) {
+          c.width = image.naturalWidth;
+          c.height = image.naturalHeight;
+        } else {
+          c.width = image.width;
+          c.height = image.height;
+        }
+        ctx.drawImage(image, 0, 0);
+        return smartcrop.Promise.resolve(c);
+      },
+      // Takes an image (as returned by open), and changes it's size by resampling
+      resample: function(image, width, height) {
+        return Promise.resolve(image).then(function(image) {
+          var c = canvasFactory(~~width, ~~height);
+          var ctx = c.getContext('2d');
+
+          ctx.drawImage(
+            image,
+            0,
+            0,
+            image.width,
+            image.height,
+            0,
+            0,
+            c.width,
+            c.height
+          );
+          return smartcrop.Promise.resolve(c);
+        });
+      },
+      getData: function(image) {
+        return Promise.resolve(image).then(function(c) {
+          var ctx = c.getContext('2d');
+          var id = ctx.getImageData(0, 0, c.width, c.height);
+          return new ImgData(c.width, c.height, id.data);
+        });
+      }
+    };
+  }
+  smartcrop._canvasImageOperations = canvasImageOperations;
+
+  // Aliases and helpers
+  var min = Math.min;
+  var max = Math.max;
+  var abs = Math.abs;
+  var sqrt = Math.sqrt;
+
+  function extend(o) {
+    for (var i = 1, iLen = arguments.length; i < iLen; i++) {
+      var arg = arguments[i];
+      if (arg) {
+        for (var name in arg) {
+          o[name] = arg[name];
+        }
+      }
+    }
+    return o;
+  }
+
+  // Gets value in the range of [0, 1] where 0 is the center of the pictures
+  // returns weight of rule of thirds [0, 1]
+  function thirds(x) {
+    x = (((x - 1 / 3 + 1.0) % 2.0) * 0.5 - 0.5) * 16;
+    return Math.max(1.0 - x * x, 0.0);
+  }
+
+  function cie(r, g, b) {
+    return 0.5126 * b + 0.7152 * g + 0.0722 * r;
+  }
+  function sample(id, p) {
+    return cie(id[p], id[p + 1], id[p + 2]);
+  }
+  function saturation(r, g, b) {
+    var maximum = max(r / 255, g / 255, b / 255);
+    var minimum = min(r / 255, g / 255, b / 255);
+
+    if (maximum === minimum) {
+      return 0;
+    }
+
+    var l = (maximum + minimum) / 2;
+    var d = maximum - minimum;
+
+    return l > 0.5 ? d / (2 - maximum - minimum) : d / (maximum + minimum);
+  }
+
+  // Amd
+  if (typeof define !== 'undefined' && define.amd)
+    define(function() {
+      return smartcrop;
+    });
+  // Common js
+  if (typeof exports !== 'undefined') exports.smartcrop = smartcrop;
+  else if (typeof navigator !== 'undefined')
+    // Browser
+    window.SmartCrop = window.smartcrop = smartcrop;
+  // Nodejs
+  if (typeof module !== 'undefined') {
+    module.exports = smartcrop;
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -4262,12 +4262,20 @@
       }
     }
 
+    // Each call clears the strip synchronously but repopulates it via async
+    // FileReader reads. If a second call lands before the first call's reads
+    // resolve, both sets of reads append — visible as duplicated cards. The
+    // generation token makes any overlapping/duplicate call safe: only the
+    // most recent call's reads are allowed to actually append.
+    let pendingRenderGen = 0;
     function renderPendingFiles() {
       const strip = document.getElementById('uploadThumbStrip');
       strip.innerHTML = '';
+      const gen = ++pendingRenderGen;
       pendingFiles.forEach((file, idx) => {
         const reader = new FileReader();
         reader.onload = e => {
+          if (gen !== pendingRenderGen) return;  // superseded by a newer render
           const item = document.createElement('div');
           item.className = 'upload-thumb-item';
           const a = pendingAnalysis[idx];
@@ -4295,13 +4303,13 @@
     // cropQueue flow — lets users adjust crops even on already-compliant
     // images (e.g. to zoom past an unwanted border). Reuses the existing
     // cropResolve short-circuit already honored by applyCrop/skipCropFile/
-    // removeCropFile/closeCropModal.
+    // removeCropFile/closeCropModal. Doesn't re-render here: applyCrop() and
+    // removeCropFile() already re-render before resolving, and skip/cancel
+    // don't change pendingFiles/pendingAnalysis, so nothing needs a refresh.
     function editPendingCrop(idx) {
       return new Promise(resolve => {
         cropResolve = resolve;
         openCropModal(idx);
-      }).then(() => {
-        if (pendingFiles.length) renderPendingFiles();
       });
     }
 

--- a/index.html
+++ b/index.html
@@ -218,6 +218,17 @@
   button.primary:hover { background: var(--color-charcoal); box-shadow: var(--shadow-pop) var(--color-soot); }
   button.danger { background: var(--color-gallery-white); border-color: var(--danger); color: var(--danger); }
   button.danger:hover { background: var(--color-vermillion-50); box-shadow: 3px 3px 0 var(--danger); }
+  /* Demoted/secondary actions — visually recedes so primary actions dominate. */
+  button.ghost {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text2);
+    box-shadow: none;
+    text-transform: none;
+    font-weight: 500;
+    letter-spacing: normal;
+  }
+  button.ghost:hover { border-color: var(--text2); color: var(--text); box-shadow: none; transform: none; }
   button:disabled { opacity: 0.4; cursor: default; box-shadow: none; transform: none; }
 
   select {
@@ -449,7 +460,7 @@
     text-align: center;
     color: var(--text2);
     cursor: pointer;
-    transition: border-color 0.2s, background 0.2s;
+    transition: border-color 0.2s, background 0.2s, padding 0.2s;
     margin: var(--space-lg);
     background: var(--color-linen);
   }
@@ -464,6 +475,16 @@
     background: var(--color-ultramarine-50);
   }
 
+  /* Collapsed: a review session is active, so the drop target recedes to a
+     slim "+ Add more files" bar instead of holding its full empty-state size. */
+  .upload-zone.collapsed {
+    padding: 10px var(--space-md);
+  }
+  .upload-zone.collapsed p {
+    font-size: 12px;
+    margin: 0;
+  }
+
   @keyframes upload-pulse {
     0%, 100% { box-shadow: 0 0 0 0 rgba(43,79,160,0.15); }
     50% { box-shadow: 0 0 20px 4px rgba(43,79,160,0.1); }
@@ -474,41 +495,57 @@
 
   .upload-zone input[type="file"] { display: none; }
 
+  /* Step indicator — shown only while a review session is active, so the
+     Select -> Review/Crop -> Upload sequence is visible without hovering. */
+  .upload-step-bar {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    margin: var(--space-md) var(--space-lg) 0;
+    font-size: 12px;
+    color: var(--text2);
+    font-family: var(--font-display);
+  }
+  .upload-step-bar.active { display: flex; }
+  .upload-step-bar .step { color: var(--text2); }
+  .upload-step-bar .step.current { color: var(--accent); font-weight: 600; }
+  .upload-step-bar .step-sep { color: var(--border); }
+
   /* Upload preview */
   .upload-preview {
     display: none;
-    margin: 0 32px 24px;
+    margin: 12px 32px 24px;
     padding: 16px;
     background: var(--surface);
     border-radius: var(--radius);
     border: 1px solid var(--border);
   }
 
-  .upload-preview.active { display: flex; gap: 20px; align-items: flex-start; }
+  .upload-preview.active { display: flex; flex-direction: column; gap: 14px; }
 
   .upload-thumb-strip {
     display: flex;
-    gap: 8px;
+    gap: 10px;
     overflow-x: auto;
-    max-width: 60%;
-    padding: 4px 0;
+    width: 100%;
+    padding: 4px 0 8px;
     align-items: flex-start;
-    flex-shrink: 0;
   }
 
   .upload-thumb-item {
     flex-shrink: 0;
-    width: 80px;
+    width: 92px;
     position: relative;
     text-align: center;
   }
 
   .upload-thumb-item img {
-    width: 80px;
-    height: 80px;
+    width: 92px;
+    height: 92px;
     object-fit: cover;
     border-radius: 4px;
     background: #000;
+    display: block;
   }
 
   .upload-thumb-item .thumb-name {
@@ -517,74 +554,59 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 80px;
-    margin-top: 2px;
+    max-width: 92px;
+    margin-top: 3px;
   }
 
-  .upload-thumb-item .thumb-remove {
-    position: absolute;
-    top: -4px;
-    right: -4px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: var(--danger);
-    color: #fff;
-    font-size: 12px;
-    cursor: pointer;
+  /* Status dot + label and text-link actions live BELOW the thumbnail, not
+     overlaid on it — the overlay icons + 9px badge were illegible without
+     squinting. Same horizontal-scroll footprint, just legible. */
+  .thumb-status {
     display: flex;
     align-items: center;
     justify-content: center;
-    border: none;
-    padding: 0;
-    line-height: 1;
-  }
-
-  .upload-thumb-item .thumb-edit {
-    position: absolute;
-    top: -4px;
-    left: -4px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: var(--accent, #555);
-    color: #fff;
-    font-size: 10px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: none;
-    padding: 0;
-    line-height: 1;
-  }
-
-  .compliance-badge {
-    position: absolute;
-    bottom: 20px;
-    left: 2px;
-    font-size: 9px;
-    font-weight: 600;
-    padding: 1px 5px;
-    border-radius: 3px;
+    gap: 4px;
+    font-size: 11px;
+    margin-top: 5px;
     white-space: nowrap;
-    line-height: 1.4;
   }
+  .thumb-status .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .thumb-status.pending { color: var(--text2); }
+  .thumb-status.pending .dot { background: var(--border); }
+  .thumb-status.ok { color: var(--text2); }
+  .thumb-status.ok .dot { background: rgba(68, 204, 102, 0.9); }
+  .thumb-status.warn { color: var(--text); font-weight: 600; }
+  .thumb-status.warn .dot { background: rgba(255, 180, 0, 0.95); }
 
-  .compliance-ok {
-    background: rgba(68, 204, 102, 0.85);
-    color: #000;
+  .thumb-actions {
+    margin-top: 2px;
+    white-space: nowrap;
   }
-
-  .compliance-warn {
-    background: rgba(255, 180, 0, 0.9);
-    color: #000;
+  .thumb-action-link {
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    font-size: 10px;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: normal;
+    color: var(--text2);
+    cursor: pointer;
+    text-decoration: underline;
   }
+  .thumb-action-link:hover { color: var(--accent); box-shadow: none; transform: none; }
+  .thumb-action-sep { color: var(--border); margin: 0 3px; }
 
   .upload-preview .upload-controls {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
   }
 
   .upload-preview label {
@@ -596,6 +618,34 @@
     display: flex;
     gap: 12px;
     align-items: center;
+  }
+
+  /* Footer row: matte choice on the left, status + primary actions on the
+     right — one row instead of a tall stacked block, so review stays compact. */
+  .upload-footer-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .upload-matte-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .upload-matte-group label { white-space: nowrap; }
+  .upload-footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .upload-status-text {
+    font-size: 12px;
+    color: var(--text2);
+    margin: 0;
+    white-space: nowrap;
   }
 
   .upload-progress {
@@ -650,6 +700,19 @@
     font-size: 11px;
     color: var(--text2);
   }
+
+  /* Two explicit, checked-off stages instead of one swapped text label —
+     mirrors the upload-step-bar pattern so "where am I" stays consistent. */
+  .progress-stages {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+  }
+  .progress-stages .stage { color: var(--text2); }
+  .progress-stages .stage.active { color: var(--accent); font-weight: 600; }
+  .progress-stages .stage.done { color: var(--text2); }
+  .progress-stages .stage .mark { display: inline-block; width: 14px; }
 
   /* Detail panel title */
   .detail-title-wrap {
@@ -1217,8 +1280,31 @@
     margin-bottom: 16px;
   }
 
+  /* Grouped by intent: the primary action stands alone and prominent; the
+     two "pick a starting point" resets sit together; the three "leave this
+     image" exits are visually demoted and separated by a divider. */
   .crop-actions {
     display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .crop-actions-reset {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .crop-actions-label {
+    font-size: 12px;
+    color: var(--text2);
+  }
+  .crop-actions-divider {
+    border-top: 1px solid var(--border);
+    margin: 2px 0;
+  }
+  .crop-actions-exit {
+    display: flex;
+    justify-content: flex-end;
     gap: 8px;
     flex-wrap: wrap;
   }
@@ -1961,26 +2047,38 @@
   </header>
 
   <main>
+  <div class="upload-step-bar" id="uploadStepBar">
+    <span class="step" id="stepReview">Review</span>
+    <span class="step-sep">&rarr;</span>
+    <span class="step" id="stepCrop">Crop</span>
+    <span class="step-sep">&rarr;</span>
+    <span class="step" id="stepUpload">Upload</span>
+  </div>
+
   <div class="upload-zone" id="uploadZone">
-    <h2 style="font-size:inherit;font-weight:inherit">Upload Artwork</h2>
-    <p>Drag art here. Your TV deserves it.</p>
+    <h2 id="uploadZoneTitle" style="font-size:inherit;font-weight:inherit">Upload Artwork</h2>
+    <p id="uploadZoneSubtitle">Drag art here. Your TV deserves it.</p>
     <input type="file" id="fileInput" accept="image/*" multiple>
   </div>
 
   <div class="upload-preview" id="uploadPreview">
     <div class="upload-thumb-strip" id="uploadThumbStrip"></div>
     <div class="upload-controls" id="uploadControls">
-      <label>Matte Style</label>
-      <div class="upload-matte-row">
-        <select id="uploadMatte">
-          <option value="none">None</option>
-        </select>
+      <div class="upload-footer-row">
+        <div class="upload-matte-group">
+          <label>Matte Style</label>
+          <div class="upload-matte-row">
+            <select id="uploadMatte">
+              <option value="none">None</option>
+            </select>
+          </div>
+        </div>
+        <div class="upload-footer-actions">
+          <p id="uploadStatus" class="upload-status-text"></p>
+          <button class="primary" id="uploadSubmitBtn" onclick="doUpload()" title="Upload selected artwork to your Frame TV">Upload to Frame</button>
+          <button class="ghost" onclick="cancelUpload()" title="Cancel upload and clear selection">Cancel</button>
+        </div>
       </div>
-      <div style="display:flex;gap:8px;margin-top:8px">
-        <button class="primary" id="uploadSubmitBtn" onclick="doUpload()" title="Upload selected artwork to your Frame TV">Upload to Frame</button>
-        <button onclick="cancelUpload()" title="Cancel upload and clear selection">Cancel</button>
-      </div>
-      <p id="uploadStatus" style="font-size:12px;color:var(--text2);margin-top:4px"></p>
     </div>
     <div class="upload-progress" id="uploadProgress" style="display:none"></div>
   </div>
@@ -2078,11 +2176,17 @@
       <div class="crop-info" id="cropInfo"></div>
       <div class="crop-actions">
         <button class="primary" onclick="applyCrop()" title="Save this crop and continue">Apply Crop</button>
-        <button onclick="reapplySmartCrop()" title="Return to the suggested crop, discarding manual adjustments">Smart Crop</button>
-        <button onclick="autoCrop()" title="Reset to a plain centered 16:9 crop">Center</button>
-        <button id="cropSkipBtn" onclick="skipCropFile()" title="Upload this image without cropping it to 16:9">Skip (upload as-is)</button>
-        <button onclick="removeCropFile()" title="Delete this image — it won't be uploaded">Remove</button>
-        <button onclick="closeCropModal()" title="Close without saving — resume by clicking Upload to Frame again">Cancel</button>
+        <div class="crop-actions-reset">
+          <span class="crop-actions-label">Reset to:</span>
+          <button class="ghost" onclick="reapplySmartCrop()" title="Return to the suggested crop, discarding manual adjustments">Smart Crop</button>
+          <button class="ghost" onclick="autoCrop()" title="Reset to a plain centered 16:9 crop">Center</button>
+        </div>
+        <div class="crop-actions-divider"></div>
+        <div class="crop-actions-exit">
+          <button class="ghost" id="cropSkipBtn" onclick="skipCropFile()" title="Upload this image without cropping it to 16:9">Skip (upload as-is)</button>
+          <button class="danger" onclick="removeCropFile()" title="Delete this image — it won't be uploaded">Remove</button>
+          <button class="ghost" onclick="closeCropModal()" title="Close without saving — resume by clicking Upload to Frame again">Cancel</button>
+        </div>
       </div>
     </div>
   </div>
@@ -2285,6 +2389,7 @@
     let mattes = null;
     let pendingFiles = [];
     let pendingAnalysis = [];
+    let uploadStage = 'review';  // 'review' | 'crop' | 'upload' — drives #uploadStepBar
     let collections = [];
     let activeCollectionId = null;
     const thumbCache = {};
@@ -3608,16 +3713,23 @@
         showToast(`${oversized.map(f => f.name).join(', ')} exceed${oversized.length === 1 ? 's' : ''} the ${MAX_MB}MB limit`, 'error');
         return;
       }
-      pendingFiles = [...files];
-      pendingAnalysis = new Array(pendingFiles.length).fill(null);
+      // Append to an in-progress review batch rather than replacing it — the
+      // collapsed "+ Add more files" zone reads as "add", and silently
+      // discarding crops already made on the current batch was a footgun.
+      const startIdx = pendingFiles.length;
+      pendingFiles = pendingFiles.concat([...files]);
+      pendingAnalysis = pendingAnalysis.concat(new Array(files.length).fill(null));
+      setUploadStage('review');
       renderPendingFiles();
-      pendingFiles.forEach((file, idx) => {
+      [...files].forEach((file, i) => {
+        const idx = startIdx + i;
         analyzeImage(file).then(analysis => {
           pendingAnalysis[idx] = analysis;
-          const badge = document.getElementById('compBadge_' + idx);
-          if (badge) {
-            badge.innerHTML = getComplianceBadgeHTML(analysis);
-            badge.className = 'compliance-badge ' + (analysis.compliant ? 'compliance-ok' : 'compliance-warn');
+          const status = document.getElementById('thumbStatus_' + idx);
+          if (status) {
+            const s = getThumbStatusHTML(analysis);
+            status.innerHTML = s.html;
+            status.className = 'thumb-status ' + s.cls;
           }
           updateUploadButtonLabel();
         });
@@ -3625,18 +3737,66 @@
       updateUploadButtonLabel();
     }
 
+    // Toggle the drop zone between its full empty-state prompt and a slim,
+    // muted "+ Add more files" bar once a review session is active. Stays a
+    // functional drop target either way — it recedes, it doesn't disappear.
+    function setUploadZoneCollapsed(collapsed) {
+      const zone = document.getElementById('uploadZone');
+      zone.classList.toggle('collapsed', collapsed);
+      document.getElementById('uploadZoneTitle').style.display = collapsed ? 'none' : '';
+      document.getElementById('uploadZoneSubtitle').textContent =
+        collapsed ? '+ Add more files' : 'Drag art here. Your TV deserves it.';
+    }
+
+    // Drives the Review -> Crop -> Upload step bar. Crop/Upload only ever
+    // become "current" when that stage actually starts (queue opens / final
+    // upload begins) — cancelling mid-crop leaves it on Crop, which is the
+    // point: unfinished work stays visibly unfinished.
+    function setUploadStage(stage) {
+      uploadStage = stage;
+      const bar = document.getElementById('uploadStepBar');
+      bar.classList.toggle('active', pendingFiles.length > 0);
+      ['stepReview', 'stepCrop', 'stepUpload'].forEach(id => {
+        document.getElementById(id).classList.remove('current');
+      });
+      const map = { review: 'stepReview', crop: 'stepCrop', upload: 'stepUpload' };
+      const el = document.getElementById(map[stage]);
+      if (el) el.classList.add('current');
+    }
+
     // Reflect whether any pending image still needs a 16:9 crop, so the upload
     // button doesn't imply an immediate upload when a review step is coming.
+    // Also drives the step bar's Crop segment and the footer status line.
     function updateUploadButtonLabel() {
       const btn = document.getElementById('uploadSubmitBtn');
       if (!btn) return;
-      const pending = pendingAnalysis.some(a => a && !a.compliant && a.issues.includes('not-16:9'));
-      if (pending) {
+      const analyzed = pendingAnalysis.filter(a => a !== null).length;
+      const needCrop = pendingAnalysis.filter(a => a && !a.compliant && a.issues.includes('not-16:9')).length;
+      if (needCrop > 0) {
         btn.textContent = 'Adjust Crops & Upload';
         btn.title = "Some images need a 16:9 crop — you'll review them before they're sent to the TV";
       } else {
         btn.textContent = 'Upload to Frame';
         btn.title = 'Upload selected artwork to your Frame TV';
+      }
+
+      const stepCrop = document.getElementById('stepCrop');
+      if (stepCrop) {
+        stepCrop.classList.remove('done');
+        if (analyzed < pendingFiles.length) {
+          stepCrop.textContent = 'Crop';
+        } else if (needCrop > 0) {
+          stepCrop.textContent = `Crop (${needCrop} needed)`;
+        } else {
+          stepCrop.textContent = '✓ No crop needed';
+          stepCrop.classList.add('done');
+        }
+      }
+
+      const status = document.getElementById('uploadStatus');
+      if (status && pendingFiles.length) {
+        const base = `${pendingFiles.length} file${pendingFiles.length > 1 ? 's' : ''} selected`;
+        status.textContent = needCrop > 0 ? `${base} — ${needCrop} need${needCrop === 1 ? 's' : ''} cropping` : `${base} — ready`;
       }
     }
 
@@ -3662,13 +3822,18 @@
       });
     }
 
-    function getComplianceBadgeHTML(analysis) {
-      if (analysis.compliant) return '\u2713';
+    // Status dot + short label shown below each thumbnail (not overlaid on
+    // the image \u2014 that's what made the old 9px corner badge illegible).
+    function getThumbStatusHTML(analysis) {
+      const dot = '<span class="dot"></span>';
+      if (!analysis) return { cls: 'pending', html: dot + 'Checking\u2026' };
+      if (analysis.compliant) return { cls: 'ok', html: dot + 'Ready' };
       const labels = [];
-      if (analysis.issues.includes('not-16:9')) labels.push('Not 16:9');
+      if (analysis.issues.includes('not-16:9')) labels.push('Needs crop');
       if (analysis.issues.includes('low-res')) labels.push('Low res');
       if (analysis.issues.includes('oversized')) labels.push('Large');
-      return '\u26A0 ' + labels.join(', ');
+      if (analysis.issues.includes('unreadable')) labels.push('Unreadable');
+      return { cls: 'warn', html: dot + labels.join(', ') };
     }
 
     // --- Crop Editor ---
@@ -4102,22 +4267,23 @@
           const item = document.createElement('div');
           item.className = 'upload-thumb-item';
           const a = pendingAnalysis[idx];
-          const badgeClass = a ? ('compliance-badge ' + (a.compliant ? 'compliance-ok' : 'compliance-warn')) : 'compliance-badge';
-          const badgeHTML = a ? getComplianceBadgeHTML(a) : '';
+          const s = getThumbStatusHTML(a);
           item.innerHTML = `
-            <button class="thumb-remove" onclick="removePendingFile(${idx})" title="Remove from upload queue" aria-label="Remove">&times;</button>
-            <button class="thumb-edit" onclick="editPendingCrop(${idx})" title="Adjust crop" aria-label="Adjust crop">&#9999;</button>
             <img src="${e.target.result}">
-            <span class="${badgeClass}" id="compBadge_${idx}">${badgeHTML}</span>
+            <div class="thumb-status ${s.cls}" id="thumbStatus_${idx}">${s.html}</div>
+            <div class="thumb-actions">
+              <button class="thumb-action-link" onclick="editPendingCrop(${idx})">Crop</button>
+              <span class="thumb-action-sep">&middot;</span>
+              <button class="thumb-action-link" onclick="removePendingFile(${idx})">Remove</button>
+            </div>
             <div class="thumb-name" title="${file.name}">${file.name}</div>
           `;
           strip.appendChild(item);
         };
         reader.readAsDataURL(file);
       });
-      document.getElementById('uploadPreview').classList.add('active');
-      document.getElementById('uploadStatus').textContent =
-        `${pendingFiles.length} file${pendingFiles.length > 1 ? 's' : ''} selected`;
+      document.getElementById('uploadPreview').classList.toggle('active', pendingFiles.length > 0);
+      setUploadZoneCollapsed(pendingFiles.length > 0);
       updateUploadButtonLabel();
     }
 
@@ -4149,6 +4315,8 @@
       document.getElementById('uploadThumbStrip').style.display = '';
       document.getElementById('uploadControls').style.display = '';
       document.getElementById('uploadProgress').style.display = 'none';
+      setUploadZoneCollapsed(false);
+      setUploadStage('review');
       fileInput.value = '';
     }
 
@@ -4204,6 +4372,7 @@
       }
 
       if (nonCompliant.length > 0) {
+        setUploadStage('crop');
         cropQueue = nonCompliant;
         cropQueueIndex = 0;
         cropPrefetch.clear();
@@ -4218,6 +4387,7 @@
 
     async function doFinalUpload() {
       if (!pendingFiles.length) { cancelUpload(); return; }
+      setUploadStage('upload');
       const matte = document.getElementById('uploadMatte').value;
 
       document.getElementById('uploadThumbStrip').style.display = 'none';
@@ -4231,11 +4401,16 @@
         shouldAnalyze = cfg.auto_analyze && cfg.claude?.api_key;
       } catch (err) { console.debug('Auto-analyze config check failed:', err); }
 
+      // Two explicit, checked-off stages instead of one swapped text label —
+      // the analyze row only exists in the DOM when analysis is actually on.
       progressDiv.innerHTML = `
         <div class="progress-label" id="progressLabel">Preparing upload...</div>
         <div class="progress-bar-track"><div class="progress-bar-fill" id="progressBar"></div></div>
+        <div class="progress-stages">
+          <span class="stage" id="stageUpload"><span class="mark">○</span>Uploading to TV</span>
+          ${shouldAnalyze ? '<span class="stage" id="stageAnalyze"><span class="mark">○</span>Analyzing with AI</span>' : ''}
+        </div>
         <div class="progress-overall">
-          <span id="progressStage"></span>
           <span id="progressOverall"></span>
         </div>
         <button onclick="cancelUpload()">Cancel</button>
@@ -4251,7 +4426,14 @@
           total > 1 ? `${completed + 1} of ${total}: ${file.name}` : file.name;
         document.getElementById('progressBar').className = 'progress-bar-fill';
         document.getElementById('progressBar').style.width = '0%';
-        document.getElementById('progressStage').textContent = 'Uploading...';
+        const stageUpload = document.getElementById('stageUpload');
+        const stageAnalyze = document.getElementById('stageAnalyze');
+        stageUpload.className = 'stage active';
+        stageUpload.innerHTML = '<span class="mark">●</span>Uploading to TV';
+        if (stageAnalyze) {
+          stageAnalyze.className = 'stage';
+          stageAnalyze.innerHTML = '<span class="mark">○</span>Analyzing with AI';
+        }
         document.getElementById('progressOverall').textContent =
           total > 1 ? `${completed} of ${total} complete` : '';
 
@@ -4261,11 +4443,13 @@
             cropBox,
             onUploadProgress: (pct) => {
               document.getElementById('progressBar').style.width = pct + '%';
-              document.getElementById('progressStage').textContent = `Uploading... ${Math.round(pct)}%`;
+              stageUpload.innerHTML = `<span class="mark">●</span>Uploading to TV... ${Math.round(pct)}%`;
             },
           });
 
           completed++;
+          stageUpload.className = 'stage done';
+          stageUpload.innerHTML = '<span class="mark">✓</span>Uploaded to TV';
           if (result.content_id) {
             artworkMeta[result.content_id] = {
               title: result.title, width: result.width, height: result.height,
@@ -4274,14 +4458,19 @@
             // Stage 2: a real, separately-timed analysis call — not folded
             // into the upload request, so this stage only shows once it's
             // actually running (no fake progress for either stage).
-            if (shouldAnalyze) {
+            if (shouldAnalyze && stageAnalyze) {
               document.getElementById('progressBar').className = 'progress-bar-fill pulsing';
-              document.getElementById('progressStage').textContent = 'Analyzing with AI...';
+              stageAnalyze.className = 'stage active';
+              stageAnalyze.innerHTML = '<span class="mark">●</span>Analyzing with AI...';
               try {
                 const aiResult = await api(`/ai/analyze/${result.content_id}`, { method: 'POST', timeout: 120000 });
                 artworkMeta[result.content_id].ai_meta = aiResult.ai_meta;
+                stageAnalyze.className = 'stage done';
+                stageAnalyze.innerHTML = '<span class="mark">✓</span>Analyzed';
               } catch (e) {
                 toast(`AI analysis failed for ${file.name}`, 'error');
+                stageAnalyze.className = 'stage done';
+                stageAnalyze.innerHTML = '<span class="mark">!</span>Analysis failed';
               }
               document.getElementById('progressBar').className = 'progress-bar-fill';
             }

--- a/index.html
+++ b/index.html
@@ -3635,7 +3635,7 @@
     }
 
     // --- Crop Editor ---
-    let cropState = { file: null, img: null, zoom: 1, offsetX: 0, offsetY: 0, dragging: false, dragStartX: 0, dragStartY: 0, fileIndex: -1, seedSource: '' };
+    let cropState = { file: null, img: null, zoom: 1, offsetX: 0, offsetY: 0, dragging: false, dragStartX: 0, dragStartY: 0, fileIndex: -1, seedSource: '', userAdjusted: false };
     let cropQueue = [];
     let cropQueueIndex = 0;
     let cropResolve = null;
@@ -3730,28 +3730,40 @@
       updateCropInfo();
     }
 
-    // Seed the modal: local smartcrop floor, upgraded to the prefetched Google
-    // hint when one is available. Guards against the user advancing the queue.
-    async function seedBestCrop(fileIndex) {
-      const img = cropState.img;
-      const file = pendingFiles[fileIndex];
-      if (!img || !file || typeof SmartCrop === 'undefined') { updateCropCaption(''); return; }
-      let box = null, source = 'smartcrop';
-      try { box = await smartCropSeedBox(img); } catch (e) { console.debug('smartcrop failed', e); }
-      const pf = cropPrefetch.get(file);
-      if (pf) {
-        try {
-          const g = await pf;
-          if (g && g.box) { box = g.box; source = 'google'; }
-        } catch (e) { console.debug('crop-hint failed', e); }
-      }
-      // User may have moved to another image while we awaited.
-      if (cropState.fileIndex !== fileIndex || cropState.img !== img) return;
-      if (!box) { updateCropCaption(''); return; }
+    // Apply a source-pixel box as the modal seed, unless the user has already
+    // taken over or moved on. Returns false if the seed was suppressed.
+    function applySeedBox(fileIndex, img, box, source) {
+      // User advanced the queue, or already dragged/zoomed/centered — don't clobber.
+      if (cropState.fileIndex !== fileIndex || cropState.img !== img) return false;
+      if (cropState.userAdjusted) return false;
+      if (!box) return false;
       const e169 = expandTo169(box.x, box.y, box.w, box.h, img.naturalWidth, img.naturalHeight);
       cropState.seedSource = source;
       seedSmartCrop(e169.x, e169.y, e169.w, e169.h);
       updateCropCaption(source);
+      return true;
+    }
+
+    // Seed the modal: apply the local smartcrop floor immediately (no wait), then
+    // upgrade to the prefetched Google hint when it arrives — but never overwrite
+    // adjustments the user made while the cloud hint was in flight.
+    async function seedBestCrop(fileIndex) {
+      const img = cropState.img;
+      const file = pendingFiles[fileIndex];
+      if (!img || !file || typeof SmartCrop === 'undefined') { updateCropCaption(''); return; }
+
+      // 1. Local floor — fast, applied right away so there's no center-crop gap.
+      let localBox = null;
+      try { localBox = await smartCropSeedBox(img); } catch (e) { console.debug('smartcrop failed', e); }
+      const seeded = applySeedBox(fileIndex, img, localBox, 'smartcrop');
+      if (!seeded && !cropPrefetch.get(file)) { if (!cropState.userAdjusted) updateCropCaption(''); return; }
+
+      // 2. Cloud ceiling — upgrade when it resolves, unless the user has taken over.
+      const pf = cropPrefetch.get(file);
+      if (!pf) return;
+      let g = null;
+      try { g = await pf; } catch (e) { console.debug('crop-hint failed', e); }
+      if (g && g.box) applySeedBox(fileIndex, img, g.box, 'google');
     }
 
     function updateCropCaption(source) {
@@ -3788,13 +3800,15 @@
       const img = new Image();
       img.onload = () => {
         cropState.img = img;
-        autoCrop();
+        autoCrop();  // instant center baseline (sets userAdjusted; reset below before seeding)
         document.getElementById('cropModal').classList.add('active');
         requestAnimationFrame(() => {
           setupCropCanvas();
           drawCropCanvas();
           updateCropInfo();
-          // Upgrade the plain center crop to a content-aware seed.
+          // Clear the flag set by the internal autoCrop above, so the smart seed
+          // can apply — but any *user* action from here on suppresses late hints.
+          cropState.userAdjusted = false;
           seedBestCrop(fileIndex);
         });
       };
@@ -3823,7 +3837,7 @@
       canvas.width = wrap.clientWidth * (window.devicePixelRatio || 1);
       canvas.height = Math.round(canvas.width * 9 / 16);
 
-      canvas.onmousedown = e => { cropState.dragging = true; cropState.dragStartX = e.clientX; cropState.dragStartY = e.clientY; };
+      canvas.onmousedown = e => { cropState.dragging = true; cropState.userAdjusted = true; cropState.dragStartX = e.clientX; cropState.dragStartY = e.clientY; };
       canvas.onmousemove = e => {
         if (!cropState.dragging) return;
         const scale = getCropScale();
@@ -3836,7 +3850,7 @@
       };
       canvas.onmouseup = canvas.onmouseleave = () => { cropState.dragging = false; };
 
-      canvas.ontouchstart = e => { e.preventDefault(); const t = e.touches[0]; cropState.dragging = true; cropState.dragStartX = t.clientX; cropState.dragStartY = t.clientY; };
+      canvas.ontouchstart = e => { e.preventDefault(); const t = e.touches[0]; cropState.dragging = true; cropState.userAdjusted = true; cropState.dragStartX = t.clientX; cropState.dragStartY = t.clientY; };
       canvas.ontouchmove = e => {
         if (!cropState.dragging) return;
         const t = e.touches[0]; const scale = getCropScale();
@@ -3896,6 +3910,7 @@
     }
 
     function onCropZoom(val) {
+      cropState.userAdjusted = true;
       const oldZoom = cropState.zoom;
       cropState.zoom = val / 100;
       if (oldZoom > 0) {
@@ -3916,6 +3931,7 @@
       cropState.offsetX = 0;
       cropState.offsetY = 0;
       cropState.seedSource = 'manual';
+      cropState.userAdjusted = true;  // explicit Center press; a late hint must not override
       const cap = document.getElementById('cropCaption');
       if (cap) cap.textContent = '';
       const slider = document.getElementById('cropZoom');

--- a/index.html
+++ b/index.html
@@ -540,6 +540,25 @@
     line-height: 1;
   }
 
+  .upload-thumb-item .thumb-edit {
+    position: absolute;
+    top: -4px;
+    left: -4px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent, #555);
+    color: #fff;
+    font-size: 10px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    padding: 0;
+    line-height: 1;
+  }
+
   .compliance-badge {
     position: absolute;
     bottom: 20px;
@@ -1958,7 +1977,7 @@
         </select>
       </div>
       <div style="display:flex;gap:8px;margin-top:8px">
-        <button class="primary" onclick="doUpload()" title="Upload selected artwork to your Frame TV">Upload to Frame</button>
+        <button class="primary" id="uploadSubmitBtn" onclick="doUpload()" title="Upload selected artwork to your Frame TV">Upload to Frame</button>
         <button onclick="cancelUpload()" title="Cancel upload and clear selection">Cancel</button>
       </div>
       <p id="uploadStatus" style="font-size:12px;color:var(--text2);margin-top:4px"></p>
@@ -2058,11 +2077,12 @@
       </div>
       <div class="crop-info" id="cropInfo"></div>
       <div class="crop-actions">
-        <button class="primary" onclick="applyCrop()" title="Apply the current crop selection">Apply Crop</button>
+        <button class="primary" onclick="applyCrop()" title="Save this crop and continue">Apply Crop</button>
+        <button onclick="reapplySmartCrop()" title="Return to the suggested crop, discarding manual adjustments">Smart Crop</button>
         <button onclick="autoCrop()" title="Reset to a plain centered 16:9 crop">Center</button>
-        <button onclick="skipCropFile()" title="Upload without cropping">Skip (upload as-is)</button>
-        <button onclick="removeCropFile()" title="Remove this file from upload queue">Remove</button>
-        <button onclick="closeCropModal()" title="Cancel crop and return">Cancel</button>
+        <button id="cropSkipBtn" onclick="skipCropFile()" title="Upload this image without cropping it to 16:9">Skip (upload as-is)</button>
+        <button onclick="removeCropFile()" title="Delete this image — it won't be uploaded">Remove</button>
+        <button onclick="closeCropModal()" title="Close without saving — resume by clicking Upload to Frame again">Cancel</button>
       </div>
     </div>
   </div>
@@ -3599,8 +3619,25 @@
             badge.innerHTML = getComplianceBadgeHTML(analysis);
             badge.className = 'compliance-badge ' + (analysis.compliant ? 'compliance-ok' : 'compliance-warn');
           }
+          updateUploadButtonLabel();
         });
       });
+      updateUploadButtonLabel();
+    }
+
+    // Reflect whether any pending image still needs a 16:9 crop, so the upload
+    // button doesn't imply an immediate upload when a review step is coming.
+    function updateUploadButtonLabel() {
+      const btn = document.getElementById('uploadSubmitBtn');
+      if (!btn) return;
+      const pending = pendingAnalysis.some(a => a && !a.compliant && a.issues.includes('not-16:9'));
+      if (pending) {
+        btn.textContent = 'Adjust Crops & Upload';
+        btn.title = "Some images need a 16:9 crop — you'll review them before they're sent to the TV";
+      } else {
+        btn.textContent = 'Upload to Frame';
+        btn.title = 'Upload selected artwork to your Frame TV';
+      }
     }
 
     function analyzeImage(file) {
@@ -3635,7 +3672,7 @@
     }
 
     // --- Crop Editor ---
-    let cropState = { file: null, img: null, zoom: 1, offsetX: 0, offsetY: 0, dragging: false, dragStartX: 0, dragStartY: 0, fileIndex: -1, seedSource: '', userAdjusted: false };
+    let cropState = { file: null, img: null, zoom: 1, offsetX: 0, offsetY: 0, dragging: false, dragStartX: 0, dragStartY: 0, fileIndex: -1, seedSource: '', userAdjusted: false, bestBox: null, bestSource: '' };
     let cropQueue = [];
     let cropQueueIndex = 0;
     let cropResolve = null;
@@ -3733,15 +3770,30 @@
     // Apply a source-pixel box as the modal seed, unless the user has already
     // taken over or moved on. Returns false if the seed was suppressed.
     function applySeedBox(fileIndex, img, box, source) {
-      // User advanced the queue, or already dragged/zoomed/centered — don't clobber.
+      // User advanced the queue — this result is for a different image now.
       if (cropState.fileIndex !== fileIndex || cropState.img !== img) return false;
-      if (cropState.userAdjusted) return false;
       if (!box) return false;
       const e169 = expandTo169(box.x, box.y, box.w, box.h, img.naturalWidth, img.naturalHeight);
+      // Cache regardless of whether we apply it now, so "Smart Crop" can return
+      // to this suggestion later even if the user already took over.
+      cropState.bestBox = e169;
+      cropState.bestSource = source;
+      if (cropState.userAdjusted) return false;  // don't clobber a manual edit
       cropState.seedSource = source;
       seedSmartCrop(e169.x, e169.y, e169.w, e169.h);
       updateCropCaption(source);
       return true;
+    }
+
+    // Re-apply the last computed suggestion (smartcrop or Google), discarding
+    // any manual drag/zoom/Center. The one way back to the seed once you've
+    // started adjusting it by hand.
+    function reapplySmartCrop() {
+      if (!cropState.bestBox) return;
+      cropState.userAdjusted = false;
+      cropState.seedSource = cropState.bestSource;
+      seedSmartCrop(cropState.bestBox.x, cropState.bestBox.y, cropState.bestBox.w, cropState.bestBox.h);
+      updateCropCaption(cropState.bestSource);
     }
 
     // Seed the modal: apply the local smartcrop floor immediately (no wait), then
@@ -3794,9 +3846,15 @@
       cropState.offsetX = 0;
       cropState.offsetY = 0;
       cropState.seedSource = '';
+      cropState.bestBox = null;
+      cropState.bestSource = '';
       document.getElementById('cropFileName').textContent = file.name;
       document.getElementById('cropCaption').textContent = '';
       document.getElementById('cropUpsell').style.display = 'none';
+      // Skip ("upload as-is") only makes sense in the mandatory non-16:9 queue —
+      // editing an already-compliant image standalone makes Skip redundant with Cancel.
+      const inQueue = cropQueue.includes(fileIndex);
+      document.getElementById('cropSkipBtn').style.display = inQueue ? '' : 'none';
       const img = new Image();
       img.onload = () => {
         cropState.img = img;
@@ -3840,9 +3898,14 @@
       canvas.onmousedown = e => { cropState.dragging = true; cropState.userAdjusted = true; cropState.dragStartX = e.clientX; cropState.dragStartY = e.clientY; };
       canvas.onmousemove = e => {
         if (!cropState.dragging) return;
+        // offsetX/Y are consumed downstream (drawCropCanvas/clampOffsets/applyCrop)
+        // as offset*bs*zoom in *internal* canvas pixels, so a CSS-pixel mouse
+        // delta must be scaled up to internal pixels (* scale) then converted
+        // back through that same factor (/ bs / zoom) to track the cursor 1:1.
         const scale = getCropScale();
-        cropState.offsetX += (e.clientX - cropState.dragStartX) / scale;
-        cropState.offsetY += (e.clientY - cropState.dragStartY) / scale;
+        const bs = getCropBaseScale();
+        cropState.offsetX += (e.clientX - cropState.dragStartX) * scale / (bs * cropState.zoom);
+        cropState.offsetY += (e.clientY - cropState.dragStartY) * scale / (bs * cropState.zoom);
         cropState.dragStartX = e.clientX;
         cropState.dragStartY = e.clientY;
         clampOffsets();
@@ -3854,8 +3917,9 @@
       canvas.ontouchmove = e => {
         if (!cropState.dragging) return;
         const t = e.touches[0]; const scale = getCropScale();
-        cropState.offsetX += (t.clientX - cropState.dragStartX) / scale;
-        cropState.offsetY += (t.clientY - cropState.dragStartY) / scale;
+        const bs = getCropBaseScale();
+        cropState.offsetX += (t.clientX - cropState.dragStartX) * scale / (bs * cropState.zoom);
+        cropState.offsetY += (t.clientY - cropState.dragStartY) * scale / (bs * cropState.zoom);
         cropState.dragStartX = t.clientX;
         cropState.dragStartY = t.clientY;
         clampOffsets();
@@ -4042,6 +4106,7 @@
           const badgeHTML = a ? getComplianceBadgeHTML(a) : '';
           item.innerHTML = `
             <button class="thumb-remove" onclick="removePendingFile(${idx})" title="Remove from upload queue" aria-label="Remove">&times;</button>
+            <button class="thumb-edit" onclick="editPendingCrop(${idx})" title="Adjust crop" aria-label="Adjust crop">&#9999;</button>
             <img src="${e.target.result}">
             <span class="${badgeClass}" id="compBadge_${idx}">${badgeHTML}</span>
             <div class="thumb-name" title="${file.name}">${file.name}</div>
@@ -4053,6 +4118,21 @@
       document.getElementById('uploadPreview').classList.add('active');
       document.getElementById('uploadStatus').textContent =
         `${pendingFiles.length} file${pendingFiles.length > 1 ? 's' : ''} selected`;
+      updateUploadButtonLabel();
+    }
+
+    // Open the crop modal for a single pending image outside the mandatory
+    // cropQueue flow — lets users adjust crops even on already-compliant
+    // images (e.g. to zoom past an unwanted border). Reuses the existing
+    // cropResolve short-circuit already honored by applyCrop/skipCropFile/
+    // removeCropFile/closeCropModal.
+    function editPendingCrop(idx) {
+      return new Promise(resolve => {
+        cropResolve = resolve;
+        openCropModal(idx);
+      }).then(() => {
+        if (pendingFiles.length) renderPendingFiles();
+      });
     }
 
     function removePendingFile(idx) {
@@ -4072,7 +4152,13 @@
       fileInput.value = '';
     }
 
-    function uploadFileWithProgress(file, matte, analyze, { onUploadProgress, onAnalyzing, cropBox }) {
+    // Plain upload only — saves + pushes to the TV, then returns. AI analysis
+    // (when enabled) is a deliberately separate request (see doFinalUpload) so
+    // the progress UI can show two real, honestly-timed stages instead of one
+    // opaque blob. defer_analyze tells the server not to also fire its own
+    // fire-and-forget background analysis for this upload (that's only for
+    // callers who don't intend to analyze themselves).
+    function uploadFileWithProgress(file, matte, { onUploadProgress, cropBox }) {
       return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         const form = new FormData();
@@ -4083,9 +4169,6 @@
 
         xhr.upload.onprogress = (e) => {
           if (e.lengthComputable) onUploadProgress((e.loaded / e.total) * 100);
-        };
-        xhr.upload.onloadend = () => {
-          if (analyze) onAnalyzing();
         };
 
         xhr.onload = () => {
@@ -4098,7 +4181,7 @@
         };
 
         xhr.onerror = () => reject(new Error('Network error'));
-        xhr.open('POST', '/api/upload' + (analyze ? '?analyze=true' : ''));
+        xhr.open('POST', '/api/upload?defer_analyze=true');
         xhr.send(form);
       });
     }
@@ -4173,15 +4256,12 @@
           total > 1 ? `${completed} of ${total} complete` : '';
 
         try {
-          const result = await uploadFileWithProgress(file, matte, shouldAnalyze, {
+          // Stage 1: real byte progress through the upload + TV push.
+          const result = await uploadFileWithProgress(file, matte, {
             cropBox,
             onUploadProgress: (pct) => {
               document.getElementById('progressBar').style.width = pct + '%';
               document.getElementById('progressStage').textContent = `Uploading... ${Math.round(pct)}%`;
-            },
-            onAnalyzing: () => {
-              document.getElementById('progressBar').className = 'progress-bar-fill pulsing';
-              document.getElementById('progressStage').textContent = 'Analyzing with AI...';
             },
           });
 
@@ -4190,11 +4270,20 @@
             artworkMeta[result.content_id] = {
               title: result.title, width: result.width, height: result.height,
             };
-            if (result.ai_meta) {
-              artworkMeta[result.content_id].ai_meta = result.ai_meta;
-            }
-            if (result.ai_error) {
-              toast(`AI analysis failed for ${file.name}`, 'error');
+
+            // Stage 2: a real, separately-timed analysis call — not folded
+            // into the upload request, so this stage only shows once it's
+            // actually running (no fake progress for either stage).
+            if (shouldAnalyze) {
+              document.getElementById('progressBar').className = 'progress-bar-fill pulsing';
+              document.getElementById('progressStage').textContent = 'Analyzing with AI...';
+              try {
+                const aiResult = await api(`/ai/analyze/${result.content_id}`, { method: 'POST', timeout: 120000 });
+                artworkMeta[result.content_id].ai_meta = aiResult.ai_meta;
+              } catch (e) {
+                toast(`AI analysis failed for ${file.name}`, 'error');
+              }
+              document.getElementById('progressBar').className = 'progress-bar-fill';
             }
           }
         } catch (e) {

--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@
     padding: 10px var(--space-md);
   }
   .upload-zone.collapsed p {
-    font-size: 12px;
+    font-size: 14px;
     margin: 0;
   }
 
@@ -502,7 +502,7 @@
     align-items: center;
     gap: 8px;
     margin: var(--space-md) var(--space-lg) 0;
-    font-size: 12px;
+    font-size: 15px;
     color: var(--text2);
     font-family: var(--font-display);
   }
@@ -534,28 +534,31 @@
 
   .upload-thumb-item {
     flex-shrink: 0;
-    width: 92px;
+    width: 160px;
     position: relative;
     text-align: center;
   }
 
+  /* object-fit: contain + a fixed letterbox box, NOT cover — the whole point
+     of reviewing here is seeing what (if anything) needs cropping, which a
+     cropped-to-fill square thumbnail actively hides. */
   .upload-thumb-item img {
-    width: 92px;
-    height: 92px;
-    object-fit: cover;
+    width: 160px;
+    height: 120px;
+    object-fit: contain;
     border-radius: 4px;
     background: #000;
     display: block;
   }
 
   .upload-thumb-item .thumb-name {
-    font-size: 10px;
+    font-size: 13px;
     color: var(--text2);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 92px;
-    margin-top: 3px;
+    max-width: 160px;
+    margin-top: 5px;
   }
 
   /* Status dot + label and text-link actions live BELOW the thumbnail, not
@@ -565,14 +568,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 4px;
-    font-size: 11px;
-    margin-top: 5px;
-    white-space: nowrap;
+    gap: 5px;
+    font-size: 14px;
+    margin-top: 7px;
+    white-space: normal;
+    line-height: 1.3;
   }
   .thumb-status .dot {
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
   }
@@ -584,7 +588,7 @@
   .thumb-status.warn .dot { background: rgba(255, 180, 0, 0.95); }
 
   .thumb-actions {
-    margin-top: 2px;
+    margin-top: 4px;
     white-space: nowrap;
   }
   .thumb-action-link {
@@ -592,7 +596,7 @@
     border: none;
     box-shadow: none;
     padding: 0;
-    font-size: 10px;
+    font-size: 13px;
     font-weight: 400;
     text-transform: none;
     letter-spacing: normal;
@@ -601,7 +605,7 @@
     text-decoration: underline;
   }
   .thumb-action-link:hover { color: var(--accent); box-shadow: none; transform: none; }
-  .thumb-action-sep { color: var(--border); margin: 0 3px; }
+  .thumb-action-sep { color: var(--border); margin: 0 4px; }
 
   .upload-preview .upload-controls {
     display: flex;
@@ -610,7 +614,7 @@
   }
 
   .upload-preview label {
-    font-size: 13px;
+    font-size: 14px;
     color: var(--text2);
   }
 
@@ -642,7 +646,7 @@
     flex-wrap: wrap;
   }
   .upload-status-text {
-    font-size: 12px;
+    font-size: 14px;
     color: var(--text2);
     margin: 0;
     white-space: nowrap;
@@ -1295,7 +1299,7 @@
     flex-wrap: wrap;
   }
   .crop-actions-label {
-    font-size: 12px;
+    font-size: 14px;
     color: var(--text2);
   }
   .crop-actions-divider {

--- a/index.html
+++ b/index.html
@@ -1205,7 +1205,7 @@
     border: 1px solid var(--border);
     border-radius: 12px;
     padding: 24px;
-    max-width: 700px;
+    max-width: 860px;
     width: 95vw;
   }
 
@@ -1223,23 +1223,41 @@
     margin-bottom: 8px;
   }
 
+  .crop-canvas-row {
+    display: flex;
+    align-items: stretch;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
   .crop-canvas-wrap {
     position: relative;
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
     aspect-ratio: 16/9;
     background: #000;
     border-radius: var(--radius);
     overflow: hidden;
     cursor: grab;
-    margin-bottom: 16px;
   }
 
   .crop-canvas-wrap:active { cursor: grabbing; }
 
-  .crop-canvas-wrap canvas {
+  .crop-canvas-wrap canvas,
+  .crop-minimap-wrap canvas {
     width: 100%;
     height: 100%;
     display: block;
+  }
+
+  .crop-minimap-wrap {
+    width: 170px;
+    flex: 0 0 170px;
+    min-height: 120px;
+    background: #000;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
   }
 
   .crop-controls {
@@ -1925,6 +1943,12 @@
     .atmosphere-content { padding: 20px; }
     .atmosphere-picks { flex-direction: column; }
     .atmosphere-pick-card .pick-img { max-height: 160px; }
+    .crop-canvas-row { flex-direction: column; }
+    .crop-minimap-wrap {
+      width: 100%;
+      flex-basis: 132px;
+      min-height: 132px;
+    }
   }
 
   /* Entrance animation */
@@ -2165,8 +2189,13 @@
     <div class="crop-modal-content">
       <div class="crop-queue-indicator" id="cropQueueIndicator"></div>
       <h3>Adjust Image &mdash; <span id="cropFileName"></span></h3>
-      <div class="crop-canvas-wrap" id="cropCanvasWrap">
-        <canvas id="cropCanvas"></canvas>
+      <div class="crop-canvas-row">
+        <div class="crop-canvas-wrap" id="cropCanvasWrap">
+          <canvas id="cropCanvas"></canvas>
+        </div>
+        <div class="crop-minimap-wrap">
+          <canvas id="cropMinimap"></canvas>
+        </div>
       </div>
       <div class="crop-controls">
         <label>Zoom</label>
@@ -3866,6 +3895,7 @@
     let cropQueueIndex = 0;
     let cropResolve = null;
     let cropPrefetch = new Map();      // File -> Promise<crop-hint response | null>
+    let cropMinimapBase = null;
     let enhancedModeAvailable = null;  // cached: Google Vision key configured?
 
     // Is Enhanced Mode (a Google Vision key) configured? Cached per session.
@@ -4047,10 +4077,12 @@
       const img = new Image();
       img.onload = () => {
         cropState.img = img;
+        cropMinimapBase = null;
         autoCrop();  // instant center baseline (sets userAdjusted; reset below before seeding)
         document.getElementById('cropModal').classList.add('active');
         requestAnimationFrame(() => {
           setupCropCanvas();
+          renderCropMinimapBase();
           drawCropCanvas();
           updateCropInfo();
           // Clear the flag set by the internal autoCrop above, so the smart seed
@@ -4075,6 +4107,9 @@
       if (cropState.img) URL.revokeObjectURL(cropState.img.src);
       cropState.img = null;
       cropState.file = null;
+      cropMinimapBase = null;
+      const minimap = document.getElementById('cropMinimap');
+      if (minimap) minimap.getContext('2d').clearRect(0, 0, minimap.width, minimap.height);
       if (cropResolve) { cropResolve('cancel'); cropResolve = null; }
     }
 
@@ -4133,6 +4168,31 @@
       return Math.max(canvas.width / img.naturalWidth, canvas.height / img.naturalHeight);
     }
 
+    function getCropDrawMetrics() {
+      const canvas = document.getElementById('cropCanvas');
+      const img = cropState.img;
+      if (!img) return null;
+      const viewW = canvas.width, viewH = canvas.height;
+      const bs = getCropBaseScale();
+      const drawW = img.naturalWidth * bs * cropState.zoom;
+      const drawH = img.naturalHeight * bs * cropState.zoom;
+      const dx = (viewW - drawW) / 2 + cropState.offsetX * bs * cropState.zoom;
+      const dy = (viewH - drawH) / 2 + cropState.offsetY * bs * cropState.zoom;
+      return { viewW, viewH, drawW, drawH, dx, dy };
+    }
+
+    function getCropSourceBox() {
+      const img = cropState.img;
+      const m = getCropDrawMetrics();
+      if (!img || !m) return null;
+      return {
+        srcX: -m.dx / m.drawW * img.naturalWidth,
+        srcY: -m.dy / m.drawH * img.naturalHeight,
+        srcW: m.viewW / m.drawW * img.naturalWidth,
+        srcH: m.viewH / m.drawH * img.naturalHeight,
+      };
+    }
+
     function clampOffsets() {
       const img = cropState.img;
       if (!img) return;
@@ -4153,13 +4213,73 @@
       const img = cropState.img;
       if (!img) return;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const viewW = canvas.width, viewH = canvas.height;
-      const bs = getCropBaseScale();
-      const drawW = img.naturalWidth * bs * cropState.zoom;
-      const drawH = img.naturalHeight * bs * cropState.zoom;
-      const dx = (viewW - drawW) / 2 + cropState.offsetX * bs * cropState.zoom;
-      const dy = (viewH - drawH) / 2 + cropState.offsetY * bs * cropState.zoom;
-      ctx.drawImage(img, dx, dy, drawW, drawH);
+      const m = getCropDrawMetrics();
+      if (!m) return;
+      ctx.drawImage(img, m.dx, m.dy, m.drawW, m.drawH);
+      drawCropMinimap();
+    }
+
+    function renderCropMinimapBase() {
+      const img = cropState.img;
+      const canvas = document.getElementById('cropMinimap');
+      const wrap = canvas ? canvas.parentElement : null;
+      if (!img || !canvas || !wrap) return;
+      const dpr = window.devicePixelRatio || 1;
+      const cssW = Math.max(1, wrap.clientWidth || 170);
+      const cssH = Math.max(1, wrap.clientHeight || 120);
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+
+      const base = document.createElement('canvas');
+      base.width = canvas.width;
+      base.height = canvas.height;
+      const ctx = base.getContext('2d');
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, base.width, base.height);
+
+      const scale = Math.min(base.width / img.naturalWidth, base.height / img.naturalHeight);
+      const imageW = img.naturalWidth * scale;
+      const imageH = img.naturalHeight * scale;
+      const imageX = (base.width - imageW) / 2;
+      const imageY = (base.height - imageH) / 2;
+      ctx.drawImage(img, imageX, imageY, imageW, imageH);
+      cropMinimapBase = { canvas: base, imageX, imageY, imageW, imageH, scale, dpr };
+    }
+
+    function drawCropMinimap() {
+      const canvas = document.getElementById('cropMinimap');
+      const img = cropState.img;
+      if (!canvas || !img) return;
+      if (!cropMinimapBase || cropMinimapBase.canvas.width !== canvas.width || cropMinimapBase.canvas.height !== canvas.height) {
+        renderCropMinimapBase();
+      }
+      if (!cropMinimapBase) return;
+
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(cropMinimapBase.canvas, 0, 0);
+
+      const box = getCropSourceBox();
+      if (!box) return;
+      const x1 = Math.max(0, Math.min(img.naturalWidth, box.srcX));
+      const y1 = Math.max(0, Math.min(img.naturalHeight, box.srcY));
+      const x2 = Math.max(0, Math.min(img.naturalWidth, box.srcX + box.srcW));
+      const y2 = Math.max(0, Math.min(img.naturalHeight, box.srcY + box.srcH));
+      const rectX = cropMinimapBase.imageX + x1 * cropMinimapBase.scale;
+      const rectY = cropMinimapBase.imageY + y1 * cropMinimapBase.scale;
+      const rectW = Math.max(1, (x2 - x1) * cropMinimapBase.scale);
+      const rectH = Math.max(1, (y2 - y1) * cropMinimapBase.scale);
+      const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#c07a3f';
+
+      ctx.save();
+      ctx.lineJoin = 'round';
+      ctx.strokeStyle = 'rgba(255,255,255,0.92)';
+      ctx.lineWidth = Math.max(3, 4 * cropMinimapBase.dpr);
+      ctx.strokeRect(rectX, rectY, rectW, rectH);
+      ctx.strokeStyle = accent;
+      ctx.lineWidth = Math.max(2, 2 * cropMinimapBase.dpr);
+      ctx.strokeRect(rectX, rectY, rectW, rectH);
+      ctx.restore();
     }
 
     function onCropZoom(val) {
@@ -4208,17 +4328,9 @@
       const img = cropState.img;
       if (!img) return;
       const outW = 3840, outH = 2160;
-      const viewCanvas = document.getElementById('cropCanvas');
-      const viewW = viewCanvas.width, viewH = viewCanvas.height;
-      const bs = getCropBaseScale();
-      const drawW = img.naturalWidth * bs * cropState.zoom;
-      const drawH = img.naturalHeight * bs * cropState.zoom;
-      const dx = (viewW - drawW) / 2 + cropState.offsetX * bs * cropState.zoom;
-      const dy = (viewH - drawH) / 2 + cropState.offsetY * bs * cropState.zoom;
-      const srcX = -dx / drawW * img.naturalWidth;
-      const srcY = -dy / drawH * img.naturalHeight;
-      const srcW = viewW / drawW * img.naturalWidth;
-      const srcH = viewH / drawH * img.naturalHeight;
+      const box = getCropSourceBox();
+      if (!box) return;
+      const { srcX, srcY, srcW, srcH } = box;
 
       const offscreen = document.createElement('canvas');
       offscreen.width = outW;

--- a/index.html
+++ b/index.html
@@ -1179,6 +1179,19 @@
     min-width: 40px;
   }
 
+  .crop-caption {
+    font-size: 13px;
+    color: var(--text);
+    margin-bottom: 4px;
+    min-height: 18px;
+  }
+
+  .crop-upsell {
+    font-size: 12px;
+    color: var(--text2);
+    margin-bottom: 8px;
+  }
+
   .crop-info {
     font-size: 12px;
     color: var(--text2);
@@ -2039,10 +2052,14 @@
         <input type="range" id="cropZoom" min="100" max="400" value="100" oninput="onCropZoom(this.value)">
         <span id="cropZoomLabel">100%</span>
       </div>
+      <div class="crop-caption" id="cropCaption"></div>
+      <div class="crop-upsell" id="cropUpsell" style="display:none">
+        Crops can be sharper with <a href="#" onclick="openSettingsFromCrop();return false;">Enhanced Mode</a>.
+      </div>
       <div class="crop-info" id="cropInfo"></div>
       <div class="crop-actions">
         <button class="primary" onclick="applyCrop()" title="Apply the current crop selection">Apply Crop</button>
-        <button onclick="autoCrop()" title="Automatically fit image to 16:9">Auto-fit</button>
+        <button onclick="autoCrop()" title="Reset to a plain centered 16:9 crop">Center</button>
         <button onclick="skipCropFile()" title="Upload without cropping">Skip (upload as-is)</button>
         <button onclick="removeCropFile()" title="Remove this file from upload queue">Remove</button>
         <button onclick="closeCropModal()" title="Cancel crop and return">Cancel</button>
@@ -2118,12 +2135,12 @@
       <h3>AI Settings</h3>
 
       <div class="settings-section">
-        <div class="settings-section-title">Identification</div>
-        <div class="settings-hint" style="margin-bottom:8px">Required for auto-identifying artwork titles, artists, and dates. Without it, you'll need to enter metadata manually.</div>
+        <div class="settings-section-title">Enhanced Mode (Google Vision)</div>
+        <div class="settings-hint" style="margin-bottom:8px">One Google Vision key makes Docent smarter two ways: it <strong>identifies</strong> artworks (titles, artists, dates) by reverse image search, and it suggests <strong>better crops</strong> that frame the subject. Without a key, Docent still smart-crops locally and you enter metadata manually.</div>
         <div class="settings-group">
           <label class="settings-toggle">
             <input type="checkbox" id="useGoogleVision">
-            Use Google Vision to identify artworks
+            Use Google Vision for identification &amp; smarter cropping
           </label>
         </div>
         <div class="settings-group" id="gvKeyGroup">
@@ -2237,6 +2254,7 @@
     · <a href="https://github.com/sponsors/danmunz" target="_blank" rel="noopener">Sponsor me on GitHub</a>
   </footer>
 
+  <script src="/assets/js/smartcrop.js"></script>
   <script>
     let artItems = [];
     let currentId = null;
@@ -3593,7 +3611,10 @@
           const aspect = w / h;
           const target = 16 / 9;
           const issues = [];
-          if (Math.abs(aspect - target) > 0.01) issues.push('not-16:9');
+          // Strict trigger: anything not (near-)exactly 16:9 gets a smart-crop
+          // pass, since the local seed is free. Epsilon only absorbs float dust
+          // so genuine 3840x2160 uploads don't needlessly queue.
+          if (Math.abs(aspect - target) > 0.002) issues.push('not-16:9');
           if (w < 3840 || h < 2160) issues.push('low-res');
           if (w > 3840) issues.push('oversized');
           resolve({ width: w, height: h, aspect, compliant: issues.length === 0, issues });
@@ -3614,10 +3635,143 @@
     }
 
     // --- Crop Editor ---
-    let cropState = { file: null, img: null, zoom: 1, offsetX: 0, offsetY: 0, dragging: false, dragStartX: 0, dragStartY: 0, fileIndex: -1 };
+    let cropState = { file: null, img: null, zoom: 1, offsetX: 0, offsetY: 0, dragging: false, dragStartX: 0, dragStartY: 0, fileIndex: -1, seedSource: '' };
     let cropQueue = [];
     let cropQueueIndex = 0;
     let cropResolve = null;
+    let cropPrefetch = new Map();      // File -> Promise<crop-hint response | null>
+    let enhancedModeAvailable = null;  // cached: Google Vision key configured?
+
+    // Is Enhanced Mode (a Google Vision key) configured? Cached per session.
+    async function checkEnhancedMode() {
+      if (enhancedModeAvailable !== null) return enhancedModeAvailable;
+      try {
+        const cfg = await api('/ai/config');
+        enhancedModeAvailable = !!(cfg.use_google_vision && cfg.google_vision && cfg.google_vision.api_key);
+      } catch { enhancedModeAvailable = false; }
+      return enhancedModeAvailable;
+    }
+
+    // Only spend a cloud crop-hint call when the image is meaningfully off 16:9
+    // (>2% relative). Near-16:9 images are seeded locally for free.
+    function visionWorthwhile(analysis) {
+      if (!analysis || !analysis.aspect) return false;
+      const target = 16 / 9;
+      return Math.abs(analysis.aspect - target) / target > 0.02;
+    }
+
+    // Kick off Google crop hints for eligible queued images so cloud latency
+    // never blocks the modal. Keyed by File so it survives index splices.
+    async function prefetchCropHints(indices) {
+      if (!(await checkEnhancedMode())) return;
+      for (const i of indices) {
+        const file = pendingFiles[i];
+        if (!file || cropPrefetch.has(file)) continue;
+        if (!visionWorthwhile(pendingAnalysis[i])) continue;
+        const form = new FormData();
+        form.append('file', file);
+        cropPrefetch.set(file, fetch('/api/crop-hint', { method: 'POST', body: form })
+          .then(r => r.ok ? r.json() : null)
+          .catch(() => null));
+      }
+    }
+
+    // Expand an arbitrary salient box to the nearest 16:9 box centered on it,
+    // clamped to image bounds. Without this, a non-16:9 seed letterboxes.
+    function expandTo169(x, y, w, h, imgW, imgH) {
+      const target = 16 / 9;
+      let bw = w, bh = h;
+      if (bw / bh > target) bh = bw / target; else bw = bh * target;
+      if (bw > imgW) { bw = imgW; bh = bw / target; }
+      if (bh > imgH) { bh = imgH; bw = bh * target; }
+      const cx = x + w / 2, cy = y + h / 2;
+      const nx = Math.max(0, Math.min(imgW - bw, cx - bw / 2));
+      const ny = Math.max(0, Math.min(imgH - bh, cy - bh / 2));
+      return { x: nx, y: ny, w: bw, h: bh };
+    }
+
+    // Run smartcrop.js on a small downscale (speed) and return a source-pixel box.
+    async function smartCropSeedBox(img) {
+      const maxEdge = 256;
+      const scale = Math.min(1, maxEdge / Math.max(img.naturalWidth, img.naturalHeight));
+      const sw = Math.max(1, Math.round(img.naturalWidth * scale));
+      const sh = Math.max(1, Math.round(img.naturalHeight * scale));
+      const c = document.createElement('canvas');
+      c.width = sw; c.height = sh;
+      c.getContext('2d').drawImage(img, 0, 0, sw, sh);
+      const result = await SmartCrop.crop(c, { width: 16, height: 9 });
+      const t = result.topCrop;
+      return { x: t.x / scale, y: t.y / scale, w: t.width / scale, h: t.height / scale };
+    }
+
+    // Invert applyCrop()'s forward transform: map a source-pixel 16:9 box to the
+    // viewport's { zoom, offsetX, offsetY }. clampOffsets() is the safe backstop.
+    function seedSmartCrop(srcX, srcY, srcW, srcH) {
+      const canvas = document.getElementById('cropCanvas');
+      const viewW = canvas.width, viewH = canvas.height;
+      const img = cropState.img;
+      if (!img || srcW <= 0 || srcH <= 0) return;
+      const bs = getCropBaseScale();
+      const zoom = viewW / (srcW * bs);
+      const drawW = img.naturalWidth * bs * zoom;
+      const drawH = img.naturalHeight * bs * zoom;
+      const dx = -srcX * viewW / srcW;
+      const dy = -srcY * viewH / srcH;
+      cropState.zoom = zoom;
+      cropState.offsetX = (dx - (viewW - drawW) / 2) / (bs * zoom);
+      cropState.offsetY = (dy - (viewH - drawH) / 2) / (bs * zoom);
+      const slider = document.getElementById('cropZoom');
+      if (slider) {
+        slider.value = Math.round(Math.min(400, Math.max(100, cropState.zoom * 100)));
+        document.getElementById('cropZoomLabel').textContent = slider.value + '%';
+      }
+      clampOffsets();
+      drawCropCanvas();
+      updateCropInfo();
+    }
+
+    // Seed the modal: local smartcrop floor, upgraded to the prefetched Google
+    // hint when one is available. Guards against the user advancing the queue.
+    async function seedBestCrop(fileIndex) {
+      const img = cropState.img;
+      const file = pendingFiles[fileIndex];
+      if (!img || !file || typeof SmartCrop === 'undefined') { updateCropCaption(''); return; }
+      let box = null, source = 'smartcrop';
+      try { box = await smartCropSeedBox(img); } catch (e) { console.debug('smartcrop failed', e); }
+      const pf = cropPrefetch.get(file);
+      if (pf) {
+        try {
+          const g = await pf;
+          if (g && g.box) { box = g.box; source = 'google'; }
+        } catch (e) { console.debug('crop-hint failed', e); }
+      }
+      // User may have moved to another image while we awaited.
+      if (cropState.fileIndex !== fileIndex || cropState.img !== img) return;
+      if (!box) { updateCropCaption(''); return; }
+      const e169 = expandTo169(box.x, box.y, box.w, box.h, img.naturalWidth, img.naturalHeight);
+      cropState.seedSource = source;
+      seedSmartCrop(e169.x, e169.y, e169.w, e169.h);
+      updateCropCaption(source);
+    }
+
+    function updateCropCaption(source) {
+      const cap = document.getElementById('cropCaption');
+      const upsell = document.getElementById('cropUpsell');
+      if (source === 'google') {
+        cap.textContent = 'Smart crop by Google Vision — drag to adjust.';
+      } else if (source === 'smartcrop') {
+        cap.textContent = 'Suggested crop — drag to adjust.';
+      } else {
+        cap.textContent = '';
+      }
+      // Upsell only when no key is configured and we're on a free local seed.
+      upsell.style.display = (enhancedModeAvailable === false && source !== 'google') ? 'block' : 'none';
+    }
+
+    function openSettingsFromCrop() {
+      closeCropModal();
+      if (typeof openSettings === 'function') openSettings();
+    }
 
     function openCropModal(fileIndex) {
       const file = pendingFiles[fileIndex];
@@ -3627,7 +3781,10 @@
       cropState.zoom = 1;
       cropState.offsetX = 0;
       cropState.offsetY = 0;
+      cropState.seedSource = '';
       document.getElementById('cropFileName').textContent = file.name;
+      document.getElementById('cropCaption').textContent = '';
+      document.getElementById('cropUpsell').style.display = 'none';
       const img = new Image();
       img.onload = () => {
         cropState.img = img;
@@ -3637,6 +3794,8 @@
           setupCropCanvas();
           drawCropCanvas();
           updateCropInfo();
+          // Upgrade the plain center crop to a content-aware seed.
+          seedBestCrop(fileIndex);
         });
       };
       img.src = URL.createObjectURL(file);
@@ -3756,6 +3915,9 @@
       cropState.zoom = 1;
       cropState.offsetX = 0;
       cropState.offsetY = 0;
+      cropState.seedSource = 'manual';
+      const cap = document.getElementById('cropCaption');
+      if (cap) cap.textContent = '';
       const slider = document.getElementById('cropZoom');
       if (slider) {
         slider.value = Math.round(cropState.zoom * 100);
@@ -3799,7 +3961,13 @@
         const name = cropState.file.name.replace(/\.[^.]+$/, '') + '_cropped.jpg';
         const croppedFile = new File([blob], name, { type: 'image/jpeg' });
         pendingFiles[cropState.fileIndex] = croppedFile;
-        pendingAnalysis[cropState.fileIndex] = { width: outW, height: outH, aspect: 16/9, compliant: true, issues: [] };
+        pendingAnalysis[cropState.fileIndex] = {
+          width: outW, height: outH, aspect: 16/9, compliant: true, issues: [],
+          crop_box: {
+            x: srcX, y: srcY, w: srcW, h: srcH,
+            source: cropState.seedSource || 'manual',
+          },
+        };
         renderPendingFiles();
         document.getElementById('cropModal').classList.remove('active');
         if (cropResolve) { cropResolve('cropped'); cropResolve = null; }
@@ -3888,13 +4056,14 @@
       fileInput.value = '';
     }
 
-    function uploadFileWithProgress(file, matte, analyze, { onUploadProgress, onAnalyzing }) {
+    function uploadFileWithProgress(file, matte, analyze, { onUploadProgress, onAnalyzing, cropBox }) {
       return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         const form = new FormData();
         form.append('file', file);
         form.append('matte', matte);
         form.append('filename', file.name);
+        if (cropBox) form.append('crop_box', JSON.stringify(cropBox));
 
         xhr.upload.onprogress = (e) => {
           if (e.lengthComputable) onUploadProgress((e.loaded / e.total) * 100);
@@ -3938,6 +4107,8 @@
       if (nonCompliant.length > 0) {
         cropQueue = nonCompliant;
         cropQueueIndex = 0;
+        cropPrefetch.clear();
+        prefetchCropHints(nonCompliant);  // warm cloud hints for the whole queue
         updateQueueIndicator();
         openCropModal(cropQueue[0]);
         return;
@@ -3974,7 +4145,9 @@
       let completed = 0;
       const total = pendingFiles.length;
 
-      for (const file of pendingFiles) {
+      for (let fi = 0; fi < pendingFiles.length; fi++) {
+        const file = pendingFiles[fi];
+        const cropBox = pendingAnalysis[fi] && pendingAnalysis[fi].crop_box;
         document.getElementById('progressLabel').textContent =
           total > 1 ? `${completed + 1} of ${total}: ${file.name}` : file.name;
         document.getElementById('progressBar').className = 'progress-bar-fill';
@@ -3985,6 +4158,7 @@
 
         try {
           const result = await uploadFileWithProgress(file, matte, shouldAnalyze, {
+            cropBox,
             onUploadProgress: (pct) => {
               document.getElementById('progressBar').style.width = pct + '%';
               document.getElementById('progressStage').textContent = `Uploading... ${Math.round(pct)}%`;
@@ -4126,6 +4300,7 @@
         if (openaiKey) body.openai.api_key = openaiKey;
         if (gvKey) body.google_vision.api_key = gvKey;
         await api('/ai/config', { method: 'PUT', body });
+        enhancedModeAvailable = null;  // re-check on next crop (mid-session key change)
         toast('AI settings saved', 'success');
         if (apiKey) {
           document.getElementById('aiApiKey').placeholder = '...' + apiKey.slice(-4);

--- a/server.py
+++ b/server.py
@@ -1259,6 +1259,11 @@ async def crop_hint(file: UploadFile = File(...)):
     except Exception:
         return {"box": None, "reason": "unreadable"}
 
+    # Authoritative 2% aspect gate: a near-16:9 image doesn't need a (paid) hint,
+    # so don't spend a Vision request on one even if a caller skips the client gate.
+    if full_h and abs((full_w / full_h) - 16 / 9) / (16 / 9) <= 0.02:
+        return {"box": None, "reason": "near_16_9"}
+
     # Downscale for Vision (cost/latency); scale the returned box back to the
     # original pixel space the modal works in (matches img.naturalWidth).
     vis = img.copy()

--- a/server.py
+++ b/server.py
@@ -756,6 +756,7 @@ async def upload_art(
     file: UploadFile = File(...),
     matte: str = Form("shadowbox_polar"),
     filename: str = Form(""),
+    crop_box: str = Form(""),
     analyze: bool = Query(False),
 ):
     chunks = []
@@ -807,15 +808,33 @@ async def upload_art(
     analysis_img.save(buf, format="JPEG", quality=80)
     (ORIGINALS_DIR / f"{content_id}.jpg").write_bytes(buf.getvalue())
 
+    record = {
+        "title": original_name,
+        "original_filename": file.filename or "",
+        "width": w,
+        "height": h,
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    # Provenance: which source-pixel 16:9 window the user accepted, and which
+    # engine seeded it (smartcrop | google | manual).  The baked image is
+    # authoritative; this is informational.
+    if crop_box:
+        try:
+            cb = json.loads(crop_box)
+            if isinstance(cb, dict) and {"x", "y", "w", "h"} <= cb.keys():
+                record["crop_box"] = {
+                    "x": round(cb["x"]),
+                    "y": round(cb["y"]),
+                    "w": round(cb["w"]),
+                    "h": round(cb["h"]),
+                    "source": str(cb.get("source", "manual"))[:16],
+                }
+        except (ValueError, TypeError):
+            log.debug("Ignoring malformed crop_box for %s", content_id)
+
     async with _meta_lock:
         meta = _load_artwork_meta()
-        meta["artwork"][content_id] = {
-            "title": original_name,
-            "original_filename": file.filename or "",
-            "width": w,
-            "height": h,
-            "uploaded_at": datetime.now(timezone.utc).isoformat(),
-        }
+        meta["artwork"][content_id] = record
         _save_artwork_meta(meta)
 
     ai_result = None
@@ -1216,6 +1235,60 @@ async def test_vision_key(body: dict | None = None):
         return result
     except Exception as e:
         return {"status": "error", "message": str(e)}
+
+
+@app.post("/api/crop-hint")
+async def crop_hint(file: UploadFile = File(...)):
+    """Suggest a 16:9 crop box for a staged (pre-upload) image via Google Vision.
+
+    This is the cloud "ceiling" seed for the Adjust Image modal.  It runs at
+    crop time — independent of the analysis pipeline — and is gated on the same
+    Enhanced Mode (Google Vision) key used for identification.  Any soft failure
+    (no key, Vision disabled, no hint) returns {"box": null} so the frontend
+    silently falls back to the local smartcrop.js seed; cropping never blocks.
+    """
+    config = _load_ai_config()
+    gv_key = config.get("google_vision", {}).get("api_key", "")
+    if not (config.get("use_google_vision") and gv_key):
+        return {"box": None, "reason": "disabled"}
+
+    data = await file.read()
+    try:
+        img = Image.open(io.BytesIO(data))
+        full_w, full_h = img.size
+    except Exception:
+        return {"box": None, "reason": "unreadable"}
+
+    # Downscale for Vision (cost/latency); scale the returned box back to the
+    # original pixel space the modal works in (matches img.naturalWidth).
+    vis = img.copy()
+    vis.thumbnail((1024, 1024), Image.LANCZOS)
+    vis_w, vis_h = vis.size
+    if vis.mode not in ("RGB", "L"):
+        vis = vis.convert("RGB")
+    buf = io.BytesIO()
+    vis.save(buf, format="JPEG", quality=85)
+    image_b64 = base64.b64encode(buf.getvalue()).decode()
+
+    try:
+        box = await _google_crop_hint(gv_key, image_b64)
+    except VisionApiError as e:
+        log.warning("Crop hint failed: [%s] %s", e.status, e.message)
+        return {"box": None, "reason": e.status}
+    except Exception as e:
+        log.warning("Crop hint error: %s", e)
+        return {"box": None, "reason": "error"}
+
+    if not box:
+        return {"box": None, "reason": "no_hint"}
+
+    sx = full_w / vis_w if vis_w else 1
+    sy = full_h / vis_h if vis_h else 1
+    x = max(0, round(box[0] * sx))
+    y = max(0, round(box[1] * sy))
+    w = min(full_w - x, round(box[2] * sx))
+    h = min(full_h - y, round(box[3] * sy))
+    return {"box": {"x": x, "y": y, "w": w, "h": h, "source": "google"}}
 
 
 # --- API usage tracking ---
@@ -1650,6 +1723,46 @@ async def _call_google_vision(api_key: str, image_b64: str) -> dict | None:
         if resp.status_code != 200:
             raise _parse_vision_error(resp)
         return resp.json().get("responses", [{}])[0].get("webDetection", {})
+
+
+async def _google_crop_hint(
+    api_key: str, image_b64: str, aspect: float = 16 / 9
+) -> tuple[int, int, int, int] | None:
+    """Ask Google Vision for a CROP_HINTS box at the given aspect ratio.
+
+    Reuses the same images:annotate endpoint as identification — just a
+    different feature.  Returns a source-pixel (x, y, w, h) box, or None if
+    Vision returned no usable hint.
+    """
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            "https://vision.googleapis.com/v1/images:annotate",
+            headers={"x-goog-api-key": api_key},
+            json={
+                "requests": [{
+                    "image": {"content": image_b64},
+                    "features": [{"type": "CROP_HINTS"}],
+                    "imageContext": {"cropHintsParams": {"aspectRatios": [aspect]}},
+                }],
+            },
+        )
+        if resp.status_code != 200:
+            raise _parse_vision_error(resp)
+        hints = (
+            resp.json()
+            .get("responses", [{}])[0]
+            .get("cropHintsAnnotation", {})
+            .get("cropHints", [])
+        )
+        if not hints:
+            return None
+        verts = hints[0].get("boundingPoly", {}).get("vertices", [])
+        if not verts:
+            return None
+        xs = [v.get("x", 0) for v in verts]
+        ys = [v.get("y", 0) for v in verts]
+        x0, y0, x1, y1 = min(xs), min(ys), max(xs), max(ys)
+        return x0, y0, x1 - x0, y1 - y0
 
 
 _MUSEUM_DOMAINS = (

--- a/server.py
+++ b/server.py
@@ -758,6 +758,7 @@ async def upload_art(
     filename: str = Form(""),
     crop_box: str = Form(""),
     analyze: bool = Query(False),
+    defer_analyze: bool = Query(False),
 ):
     chunks = []
     total = 0
@@ -856,7 +857,10 @@ async def upload_art(
         except Exception as e:
             log.warning("Auto-analyze failed during upload for %s: %s", content_id, e)
             ai_result = {"error": "Analysis failed"}
-    elif should_analyze:
+    elif should_analyze and not defer_analyze:
+        # defer_analyze means the caller (the upload UI, for an honest two-stage
+        # progress bar) commits to driving analysis itself via the standalone
+        # /api/ai/analyze/{content_id} endpoint — don't double-fire here.
         asyncio.create_task(_analyze_artwork_background(content_id))
 
     resp = {"ok": True, "content_id": content_id, "title": original_name, "width": w, "height": h}


### PR DESCRIPTION
Implements **Smart Crop** (#83): seed the Adjust Image modal with a compositionally smart crop instead of a plain center cover, layered by cost into two tiers.

## What changed

**Floor — always on, free, local (no key)**
- Vendored `smartcrop.js` (MIT) at `assets/js/smartcrop.js`, run in-browser on a 256px downscale of every non-16:9 image.
- `seedSmartCrop()` inverts `applyCrop()`'s forward transform to map a source-pixel 16:9 box → `{zoom, offsetX, offsetY}`; `expandTo169()` normalizes any salient region to a clamped 16:9 box.

**Ceiling — "Enhanced Mode (Google Vision)"**
- One Google Vision key now powers **both** identification (existing) **and** cropping via `CROP_HINTS`.
- New `POST /api/crop-hint` reuses the existing Vision plumbing (`_call_google_vision` request shape, `_parse_vision_error`); downscales to 1024px for Vision then rescales the box to original pixels.
- Prefetched for the whole crop queue so cloud latency never blocks the modal.
- Gated to images **>2% off 16:9** to stay in the free tier; **any soft failure (no key, API disabled, no hint) falls back to the local seed** — cropping never blocks.

**Persistence**
- The accepted source-pixel box + engine (`smartcrop` | `google` | `manual`) are recorded as `crop_box` on the artwork record in `artwork_meta.json`. The baked 3840×2160 JPEG remains authoritative; this is provenance.

**UX / content**
- Trigger tightened to strict 16:9 (`0.01 → 0.002`); **"Auto-fit" → "Center"**.
- Modal caption ("Suggested crop…" / "Smart crop by Google Vision…") + dismissible Enhanced-Mode upsell for keyless users.
- Settings "Identification" section reframed to **"Enhanced Mode (Google Vision)"** conveying the one-key/dual-value story.

## Verification

Tested end-to-end against a running server and the **live** Vision API:

| Image | Google box | Aspect | Behavior |
|---|---|---|---|
| Portrait 800×1200 | `[0,120,799,450]` | 1.776 | shifted up to subject (center=375) |
| Panorama 3000×900 | `[1400,0,1597,897]` | 1.780 | shifted right to subject (center=701) |

- Local smartcrop seeds toward an off-center subject (not center); inverse transform round-trips exactly.
- 2% gate: 1%-off → no call, portrait → call.
- `crop_box` captured on apply; backend parsing rounds floats and rejects malformed input.
- No-key path returns `{box: null}` and falls back locally.
- Pre-commit suite: 123 passed, 6 xfailed.

Resolves the four open questions in #83 (VLM precision → moot via CROP_HINTS; two-tier engine model; bake + record persistence; strict trigger / 2% gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)