### PR TITLE
[codex] fix analyzed artwork grouping labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -2516,17 +2516,30 @@
       return key;
     }
 
+    function missingGroupLabel(item, sortField) {
+      const hasAiMeta = !!artworkMeta[item.content_id]?.ai_meta;
+      switch (sortField) {
+        case 'date_added': return 'Date Unknown';
+        case 'artist': return hasAiMeta ? 'Artist Unknown' : 'Not Yet Analyzed';
+        case 'year': return hasAiMeta ? 'Year Unknown' : 'Not Yet Analyzed';
+        case 'school': return hasAiMeta ? 'School Unknown' : 'Not Yet Analyzed';
+        case 'medium': return hasAiMeta ? 'Medium Unknown' : 'Not Yet Analyzed';
+        default: return 'Unknown';
+      }
+    }
+
     function getSortedGroupedItems(items) {
-      const SENTINEL = '\uffff';
+      const MISSING_PREFIX = '\uffff';
       const yearBuckets = currentSort === 'year' ? computeYearBuckets(items) : [];
+      const missingKey = (item) => MISSING_PREFIX + missingGroupLabel(item, currentSort);
       const getGroupKey = (item) => {
         const meta = artworkMeta[item.content_id];
         const ai = meta?.ai_meta;
         switch (currentSort) {
-          case 'artist': return ai?.artist || SENTINEL;
-          case 'year': return getYearBucket(ai?.year, yearBuckets) || SENTINEL;
-          case 'school': return (ai?.school && ai.school !== 'N/A') ? ai.school : SENTINEL;
-          case 'medium': return ai?.medium || SENTINEL;
+          case 'artist': return ai?.artist || missingKey(item);
+          case 'year': return getYearBucket(ai?.year, yearBuckets) || missingKey(item);
+          case 'school': return (ai?.school && ai.school !== 'N/A') ? ai.school : missingKey(item);
+          case 'medium': return ai?.medium || missingKey(item);
           case 'title': {
             const t = getArtworkTitle(item);
             const ch = t.charAt(0).toUpperCase();
@@ -2534,22 +2547,27 @@
           }
           case 'date_added': {
             const d = meta?.uploaded_at;
-            return d ? d.substring(0, 7) : SENTINEL;
+            return d ? d.substring(0, 7) : missingKey(item);
           }
           default: return '';
         }
       };
 
       const getSortVal = (item) => {
-        if (currentSort === 'year') return parseYearForSort(artworkMeta[item.content_id]?.ai_meta?.year);
-        if (currentSort === 'date_added') return artworkMeta[item.content_id]?.uploaded_at || SENTINEL;
+        if (currentSort === 'year') {
+          const y = parseYearForSort(artworkMeta[item.content_id]?.ai_meta?.year);
+          return y === Infinity ? getGroupKey(item) : y;
+        }
+        if (currentSort === 'date_added') return artworkMeta[item.content_id]?.uploaded_at || MISSING_PREFIX;
         return getGroupKey(item).toLowerCase();
       };
 
       const sorted = [...items].sort((a, b) => {
         const va = getSortVal(a), vb = getSortVal(b);
-        if (va === SENTINEL && vb !== SENTINEL) return 1;
-        if (vb === SENTINEL && va !== SENTINEL) return -1;
+        const aMissing = String(va).startsWith(MISSING_PREFIX);
+        const bMissing = String(vb).startsWith(MISSING_PREFIX);
+        if (aMissing && !bMissing) return 1;
+        if (bMissing && !aMissing) return -1;
         const cmp = va < vb ? -1 : va > vb ? 1 : 0;
         return currentSort === 'date_added' ? -cmp : cmp;
       });
@@ -2560,7 +2578,9 @@
       for (const item of sorted) {
         const key = getGroupKey(item);
         if (key !== lastKey) {
-          const label = key === SENTINEL ? 'Not Yet Analyzed' : formatGroupLabel(key, currentSort);
+          const label = key.startsWith(MISSING_PREFIX)
+            ? key.slice(MISSING_PREFIX.length)
+            : formatGroupLabel(key, currentSort);
           result.push({ type: 'header', label, count: 0 });
           headerIdx = result.length - 1;
           lastKey = key;

--- a/tests/test_frontend_integrity.py
+++ b/tests/test_frontend_integrity.py
@@ -94,3 +94,36 @@ class TestObserverCleanup:
             "(before creating the new observer) to prevent stale batch fetches "
             "from a previous grid render"
         )
+
+
+class TestArtworkGrouping:
+    """Grouping fallbacks should distinguish unanalyzed art from missing fields."""
+
+    def test_missing_group_labels_are_sort_specific(self, js_source):
+        fn_match = re.search(
+            r"function missingGroupLabel\(item, sortField\)\s*\{(.*?)\n\s*\}",
+            js_source,
+            re.DOTALL,
+        )
+        assert fn_match, "Cannot find missingGroupLabel()"
+        fn_body = fn_match.group(1)
+
+        assert "case 'date_added': return 'Date Unknown'" in fn_body
+        assert "hasAiMeta ? 'Artist Unknown' : 'Not Yet Analyzed'" in fn_body
+        assert "hasAiMeta ? 'Year Unknown' : 'Not Yet Analyzed'" in fn_body
+        assert "hasAiMeta ? 'School Unknown' : 'Not Yet Analyzed'" in fn_body
+        assert "hasAiMeta ? 'Medium Unknown' : 'Not Yet Analyzed'" in fn_body
+
+    def test_grouping_uses_distinct_missing_bucket_keys(self, js_source):
+        fn_match = re.search(
+            r"function getSortedGroupedItems\(items\)\s*\{(.*?)\n\s*// --- Init ---",
+            js_source,
+            re.DOTALL,
+        )
+        assert fn_match, "Cannot find getSortedGroupedItems()"
+        fn_body = fn_match.group(1)
+
+        assert "const MISSING_PREFIX" in fn_body
+        assert "MISSING_PREFIX + missingGroupLabel(item, currentSort)" in fn_body
+        assert "key.slice(MISSING_PREFIX.length)" in fn_body
+        assert "key === SENTINEL ? 'Not Yet Analyzed'" not in fn_body


### PR DESCRIPTION
## Summary

- distinguish truly unanalyzed artwork from analyzed artwork with missing grouping fields
- label missing date metadata as `Date Unknown` instead of `Not Yet Analyzed`
- add frontend integrity tests for grouping fallback labels and missing bucket keys

## Root Cause

The grid used a single sentinel label, `Not Yet Analyzed`, for every missing grouping value. An analyzed artwork like Nighthawks could still lack metadata such as `uploaded_at`, causing it to appear under the wrong group when sorting by date added.

## Validation

- `PYTHONPATH=. uv run pytest -x -q`
- pre-commit hook reran the same full test suite during commit

Result: `125 passed, 6 xfailed`