### PR TITLE
fix: update retired Claude model IDs and pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2339,9 +2339,9 @@
           <div class="settings-group">
             <label>Model</label>
             <select id="aiModel">
-              <option value="claude-sonnet-4-20250514">Sonnet 4 ($3/$15 per MTok)</option>
-              <option value="claude-haiku-4-5-20251001">Haiku 4.5 ($0.80/$4 per MTok)</option>
-              <option value="claude-opus-4-20250514">Opus 4 ($15/$75 per MTok)</option>
+              <option value="claude-sonnet-5">Sonnet 5 ($3/$15 per MTok)</option>
+              <option value="claude-haiku-4-5-20251001">Haiku 4.5 ($1/$5 per MTok)</option>
+              <option value="claude-opus-5">Opus 5 ($5/$25 per MTok)</option>
             </select>
             <div class="settings-hint">Sonnet is best for most users. Haiku is cheapest.</div>
           </div>
@@ -4663,7 +4663,7 @@
         document.getElementById('aiProvider').value = config.provider || 'claude';
         document.getElementById('aiApiKey').value = '';
         document.getElementById('aiApiKey').placeholder = config.claude?.api_key || 'sk-ant-...';
-        document.getElementById('aiModel').value = config.claude?.model || 'claude-sonnet-4-20250514';
+        document.getElementById('aiModel').value = config.claude?.model || 'claude-sonnet-5';
         document.getElementById('aiAutoAnalyze').checked = config.auto_analyze || false;
         document.getElementById('aiOpusFallback').checked = config.opus_fallback || false;
         document.getElementById('openaiApiKey').value = '';
@@ -4864,8 +4864,7 @@
         provenance.push(`<span style="color:var(--danger)">${tip}</span>`);
       }
       if (ai.provider && ai.model) {
-        const shortModel = ai.model.replace('claude-', '').replace('-20250514', '')
-          .replace('-20251001', '').replace('gpt-', 'GPT-');
+        const shortModel = ai.model.replace('claude-', '').replace('gpt-', 'GPT-');
         provenance.push(`Analysis: ${shortModel}`);
       }
       const provenanceLine = provenance.length

--- a/server.py
+++ b/server.py
@@ -1148,7 +1148,7 @@ async def update_artwork_meta(content_id: str, body: dict):
 # --- AI config ---
 
 def _load_ai_config() -> dict:
-    defaults = {"provider": "claude", "auto_analyze": False, "opus_fallback": False, "use_google_vision": True, "claude": {"api_key": "", "model": "claude-sonnet-4-6"}, "openai": {"api_key": "", "model": "gpt-4.1"}, "google_vision": {"api_key": ""}}
+    defaults = {"provider": "claude", "auto_analyze": False, "opus_fallback": False, "use_google_vision": True, "claude": {"api_key": "", "model": "claude-sonnet-5"}, "openai": {"api_key": "", "model": "gpt-4.1"}, "google_vision": {"api_key": ""}}
     saved = _safe_load_json(AI_CONFIG_FILE, lambda: None)
     if saved is None:
         return defaults
@@ -1303,9 +1303,9 @@ async def crop_hint(file: UploadFile = File(...)):
 # --- API usage tracking ---
 
 MODEL_PRICING = {
-    "claude-sonnet-4-6": {"input_per_mtok": 3.0, "output_per_mtok": 15.0},
-    "claude-haiku-4-5-20251001": {"input_per_mtok": 0.80, "output_per_mtok": 4.0},
-    "claude-opus-4-8": {"input_per_mtok": 15.0, "output_per_mtok": 75.0},
+    "claude-sonnet-5": {"input_per_mtok": 3.0, "output_per_mtok": 15.0},
+    "claude-haiku-4-5-20251001": {"input_per_mtok": 1.0, "output_per_mtok": 5.0},
+    "claude-opus-5": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
     "gpt-4.1": {"input_per_mtok": 2.0, "output_per_mtok": 8.0},
     "gpt-4.1-mini": {"input_per_mtok": 0.40, "output_per_mtok": 1.60},
     "gpt-4.1-nano": {"input_per_mtok": 0.10, "output_per_mtok": 0.40},
@@ -1545,7 +1545,7 @@ async def _analyze_artwork(content_id: str) -> dict:
         and "opus" not in model
     ):
         first_pass = parsed
-        opus_model = "claude-opus-4-8"
+        opus_model = "claude-opus-5"
         escalation = (
             f"A preliminary analysis identified this as: "
             f"school={first_pass.get('school', 'N/A')}, "
@@ -1621,6 +1621,7 @@ async def _call_claude_vision(
             json={
                 "model": model,
                 "max_tokens": 1024,
+                "thinking": {"type": "disabled"},
                 "system": AI_SYSTEM,
                 "messages": [{
                     "role": "user",
@@ -1884,8 +1885,8 @@ async def analyze_batch(body: dict):
 async def estimate_analysis(count: int = Query(...)):
     config = _load_ai_config()
     provider = config.get("provider", "claude")
-    model = config.get(provider, {}).get("model", "claude-sonnet-4-6")
-    pricing = MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-4-6"])
+    model = config.get(provider, {}).get("model", "claude-sonnet-5")
+    pricing = MODEL_PRICING.get(model, MODEL_PRICING["claude-sonnet-5"])
 
     avg_input = 1600
     avg_output = 200
@@ -2302,7 +2303,7 @@ async def atmosphere(body: dict):
     provider = config.get("provider", "claude")
     provider_config = config.get(provider, {})
     api_key = provider_config.get("api_key", "")
-    model = provider_config.get("model", "claude-sonnet-4-6" if provider == "claude" else "gpt-4.1")
+    model = provider_config.get("model", "claude-sonnet-5" if provider == "claude" else "gpt-4.1")
     if not api_key:
         raise HTTPException(400, f"{provider.title()} API key not configured. Open Settings to add it.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def seed_ai_config(tmp_data_dir):
             "auto_analyze": False,
             "opus_fallback": False,
             "use_google_vision": True,
-            "claude": {"api_key": "sk-ant-test-key-1234ZgAA", "model": "claude-sonnet-4-20250514"},
+            "claude": {"api_key": "sk-ant-test-key-1234ZgAA", "model": "claude-sonnet-5"},
             "openai": {"api_key": "", "model": "gpt-4.1"},
             "google_vision": {"api_key": ""},
         }

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -504,7 +504,7 @@ class TestUsage:
             "input_tokens": 1_000_000,
             "output_tokens": 1_000_000,
             "calls": 10,
-            "by_model": {"claude-sonnet-4-6": {
+            "by_model": {"claude-sonnet-5": {
                 "input_tokens": 1_000_000,
                 "output_tokens": 1_000_000,
                 "calls": 10,

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -57,7 +57,7 @@ class TestApiUsageConcurrency:
 
         # Directly call _record_api_usage in rapid succession
         for _ in range(10):
-            server._record_api_usage("claude-sonnet-4-20250514", 100, 50)
+            server._record_api_usage("claude-sonnet-5", 100, 50)
 
         resp = await client.get("/api/ai/usage")
         data = resp.json()

--- a/tests/test_file_persistence.py
+++ b/tests/test_file_persistence.py
@@ -19,7 +19,7 @@ class TestLoadAiConfig:
         assert config["google_vision"]["api_key"] == ""
 
     def test_old_file_missing_new_keys(self, tmp_data_dir):
-        old = {"auto_analyze": True, "claude": {"api_key": "sk-test", "model": "claude-sonnet-4-6"}}
+        old = {"auto_analyze": True, "claude": {"api_key": "sk-test", "model": "claude-sonnet-5"}}
         (tmp_data_dir / "ai_config.json").write_text(json.dumps(old))
         config = server._load_ai_config()
         assert config["auto_analyze"] is True
@@ -36,7 +36,7 @@ class TestLoadAiConfig:
         (tmp_data_dir / "ai_config.json").write_text(json.dumps(partial))
         config = server._load_ai_config()
         assert config["claude"]["api_key"] == "sk-test"
-        assert config["claude"]["model"] == "claude-sonnet-4-6"
+        assert config["claude"]["model"] == "claude-sonnet-5"
 
     def test_complete_file_unchanged(self, tmp_data_dir):
         full = {
@@ -44,7 +44,7 @@ class TestLoadAiConfig:
             "auto_analyze": True,
             "opus_fallback": True,
             "use_google_vision": False,
-            "claude": {"api_key": "sk-c", "model": "claude-opus-4-8"},
+            "claude": {"api_key": "sk-c", "model": "claude-opus-5"},
             "openai": {"api_key": "sk-o", "model": "gpt-4o"},
             "google_vision": {"api_key": "AIza-gv"},
         }
@@ -61,7 +61,7 @@ class TestLoadAiConfig:
 
 class TestRecordApiUsage:
     def test_creates_file_on_first_call(self, tmp_data_dir):
-        server._record_api_usage("claude-sonnet-4-6", 100, 50)
+        server._record_api_usage("claude-sonnet-5", 100, 50)
         data = json.loads((tmp_data_dir / "api_usage.json").read_text())
         month_data = list(data["monthly"].values())[0]
         assert month_data["input_tokens"] == 100
@@ -78,11 +78,11 @@ class TestRecordApiUsage:
         assert month_data["calls"] == 2
 
     def test_multiple_models(self, tmp_data_dir):
-        server._record_api_usage("claude-sonnet-4-6", 100, 50)
+        server._record_api_usage("claude-sonnet-5", 100, 50)
         server._record_api_usage("gpt-4.1", 200, 80)
         data = json.loads((tmp_data_dir / "api_usage.json").read_text())
         by_model = list(data["monthly"].values())[0]["by_model"]
-        assert "claude-sonnet-4-6" in by_model
+        assert "claude-sonnet-5" in by_model
         assert "gpt-4.1" in by_model
         assert by_model["gpt-4.1"]["input_tokens"] == 200
 
@@ -133,7 +133,7 @@ class TestCostCalculation:
                     "output_tokens": 1_000_000,
                     "calls": 10,
                     "by_model": {
-                        "claude-sonnet-4-6": {
+                        "claude-sonnet-5": {
                             "input_tokens": 1_000_000,
                             "output_tokens": 1_000_000,
                             "calls": 10,


### PR DESCRIPTION
## Summary
- Replace retired `claude-sonnet-4-*` / `claude-opus-4-*` model IDs with `claude-sonnet-5` / `claude-opus-5` in the UI model picker, AI config defaults, pricing table, and escalation logic
- Refresh Haiku 4.5 pricing ($1/$5 per MTok) and disable extended thinking on vision calls (`"thinking": {"type": "disabled"}`)
- Update tests to reference the current model IDs

## Test plan
- [ ] `pytest tests/` (could not run locally in this environment: missing `samsungtvws` dependency / no `uv` available)